### PR TITLE
Hyprland 0.55 support (first draft)

### DIFF
--- a/OverviewPassElement.cpp
+++ b/OverviewPassElement.cpp
@@ -14,11 +14,14 @@
 #include <utility>
 #include <vector>
 #define private public
+#include <hyprland/src/render/Renderer.hpp>
 #include <hyprland/src/render/OpenGL.hpp>
 #include <hyprland/src/helpers/math/Math.hpp>
 #undef private
 #include <hyprutils/utils/ScopeGuard.hpp>
 #include "IOverview.hpp"
+
+using Render::GL::g_pHyprOpenGL;
 
 static CRegion roundedRectRegion(const CBox& box, int rounding, float roundingPower) {
     const auto ROUNDEDBOX = box.copy().round();
@@ -128,9 +131,9 @@ void COverviewShadowPassElement::draw(const CRegion& damage) {
     if (shadowDamage.empty())
         return;
 
-    const auto SAVEDDAMAGE = g_pHyprOpenGL->m_renderData.damage;
-    g_pHyprOpenGL->m_renderData.damage = shadowDamage;
-    auto restoreDamage = Hyprutils::Utils::CScopeGuard([SAVEDDAMAGE] { g_pHyprOpenGL->m_renderData.damage = SAVEDDAMAGE; });
+    const auto SAVEDDAMAGE = g_pHyprRenderer->m_renderData.damage;
+    g_pHyprRenderer->m_renderData.damage = shadowDamage;
+    auto restoreDamage = Hyprutils::Utils::CScopeGuard([SAVEDDAMAGE] { g_pHyprRenderer->m_renderData.damage = SAVEDDAMAGE; });
 
     auto color = data.color;
     color.a *= data.alpha;

--- a/OverviewPassElement.hpp
+++ b/OverviewPassElement.hpp
@@ -16,6 +16,10 @@ class CScrollOverviewPassElement : public IPassElement {
     virtual const char*         passName() {
         return "CScrollOverviewPassElement";
     }
+
+    virtual ePassElementType type() {
+        return EK_CUSTOM;
+    }
 };
 
 class COverviewShadowPassElement : public IPassElement {
@@ -45,6 +49,10 @@ class COverviewShadowPassElement : public IPassElement {
 
     virtual const char*         passName() {
         return "COverviewShadowPassElement";
+    }
+
+    virtual ePassElementType type() {
+        return EK_CUSTOM;
     }
 
   private:

--- a/OverviewRender.cpp
+++ b/OverviewRender.cpp
@@ -5,8 +5,13 @@
 #define private public
 #include <hyprland/src/render/Renderer.hpp>
 #include <hyprland/src/render/OpenGL.hpp>
+#include <hyprland/src/render/gl/GLFramebuffer.hpp>
+#include <hyprland/src/helpers/MonitorResources.hpp>
 #include <hyprland/src/helpers/math/Math.hpp>
 #undef private
+
+using Render::GL::g_pHyprOpenGL;
+using Render::GL::CHyprOpenGLImpl;
 
 namespace OverviewRender {
 
@@ -28,17 +33,19 @@ void renderBlur(PHLMONITOR monitor, const CBox& windowBox, int rounding, float r
 
     CRegion drawDamage{CBox{{}, monitor->m_transformedSize}};
 
-    auto* const SAVEDFB            = g_pHyprOpenGL->m_renderData.currentFB;
-    CFramebuffer* const BLURREDFB = usePrecomputedBlur && g_pHyprOpenGL->m_renderData.pCurrentMonData ? &g_pHyprOpenGL->m_renderData.pCurrentMonData->blurFB :
-                                                                                                          g_pHyprOpenGL->blurMainFramebufferWithDamage(alpha, &blurDamage);
+    const auto SAVEDFB        = g_pHyprRenderer->m_renderData.currentFB;
+    const auto MONITORRES     = monitor->resources().lock();
+    const auto PRECOMPUTEDFB  = (usePrecomputedBlur && MONITORRES) ? MONITORRES->m_blurFB : nullptr;
+
+    SP<Render::ITexture> BLURREDTEXTURE;
+    if (PRECOMPUTEDFB)
+        BLURREDTEXTURE = PRECOMPUTEDFB->getTexture();
+    else if (g_pHyprRenderer->m_renderData.mainFB)
+        BLURREDTEXTURE = g_pHyprRenderer->blurMainFramebuffer(alpha, &blurDamage);
 
     if (SAVEDFB)
         SAVEDFB->bind();
 
-    if (!BLURREDFB)
-        return;
-
-    const auto BLURREDTEXTURE = BLURREDFB->getTexture();
     if (!BLURREDTEXTURE)
         return;
 
@@ -58,18 +65,18 @@ void renderBlur(PHLMONITOR monitor, const CBox& windowBox, int rounding, float r
     renderData.allowCustomUV                        = true;
     renderData.allowDim                             = false;
 
-    g_pHyprOpenGL->pushMonitorTransformEnabled(true);
-    const auto SAVEDRENDERMODIF                     = g_pHyprOpenGL->m_renderData.renderModif;
-    const auto SAVEDUVTOPLEFT                       = g_pHyprOpenGL->m_renderData.primarySurfaceUVTopLeft;
-    const auto SAVEDUVBOTTOMRIGHT                   = g_pHyprOpenGL->m_renderData.primarySurfaceUVBottomRight;
-    g_pHyprOpenGL->m_renderData.renderModif         = {};
-    g_pHyprOpenGL->m_renderData.primarySurfaceUVTopLeft     = monitorSpaceBox.pos() / monitor->m_transformedSize;
-    g_pHyprOpenGL->m_renderData.primarySurfaceUVBottomRight = (monitorSpaceBox.pos() + monitorSpaceBox.size()) / monitor->m_transformedSize;
+    g_pHyprRenderer->pushMonitorTransformEnabled(true);
+    const auto SAVEDRENDERMODIF                     = g_pHyprRenderer->m_renderData.renderModif;
+    const auto SAVEDUVTOPLEFT                       = g_pHyprRenderer->m_renderData.primarySurfaceUVTopLeft;
+    const auto SAVEDUVBOTTOMRIGHT                   = g_pHyprRenderer->m_renderData.primarySurfaceUVBottomRight;
+    g_pHyprRenderer->m_renderData.renderModif         = {};
+    g_pHyprRenderer->m_renderData.primarySurfaceUVTopLeft     = monitorSpaceBox.pos() / monitor->m_transformedSize;
+    g_pHyprRenderer->m_renderData.primarySurfaceUVBottomRight = (monitorSpaceBox.pos() + monitorSpaceBox.size()) / monitor->m_transformedSize;
     g_pHyprOpenGL->renderTexture(BLURREDTEXTURE, windowBox, renderData);
-    g_pHyprOpenGL->m_renderData.primarySurfaceUVTopLeft     = SAVEDUVTOPLEFT;
-    g_pHyprOpenGL->m_renderData.primarySurfaceUVBottomRight = SAVEDUVBOTTOMRIGHT;
-    g_pHyprOpenGL->m_renderData.renderModif                 = SAVEDRENDERMODIF;
-    g_pHyprOpenGL->popMonitorTransformEnabled();
+    g_pHyprRenderer->m_renderData.primarySurfaceUVTopLeft     = SAVEDUVTOPLEFT;
+    g_pHyprRenderer->m_renderData.primarySurfaceUVBottomRight = SAVEDUVBOTTOMRIGHT;
+    g_pHyprRenderer->m_renderData.renderModif                 = SAVEDRENDERMODIF;
+    g_pHyprRenderer->popMonitorTransformEnabled();
 }
 
 }

--- a/RendererAccess.hpp
+++ b/RendererAccess.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+// Hyprland 0.55 moved several CHyprRenderer render entry points into the
+// protected section of Render::IHyprRenderer. A derived class may legally
+// name a protected base member to form a pointer-to-member; invoking
+// through that pointer performs no access check. Standard-compliant C++,
+// and avoids the `#define protected public` shim.
+
+#include <hyprland/src/render/Renderer.hpp>
+
+namespace ScrollOverview::RendererAccess {
+    struct SExposed : public Render::IHyprRenderer {
+        using Render::IHyprRenderer::renderBackground;
+        using Render::IHyprRenderer::renderLayer;
+        using Render::IHyprRenderer::renderWindow;
+        using Render::IHyprRenderer::shouldBlur;
+    };
+
+    inline void renderBackground(PHLMONITOR monitor) {
+        (g_pHyprRenderer.get()->*&SExposed::renderBackground)(monitor);
+    }
+
+    inline void renderLayer(PHLLS layer, PHLMONITOR monitor, const Time::steady_tp& now, bool popups = false, bool lockscreen = false) {
+        (g_pHyprRenderer.get()->*&SExposed::renderLayer)(layer, monitor, now, popups, lockscreen);
+    }
+
+    inline void renderWindow(PHLWINDOW window, PHLMONITOR monitor, const Time::steady_tp& now, bool decorate, Render::eRenderPassMode mode, bool ignorePosition = false, bool standalone = false) {
+        (g_pHyprRenderer.get()->*&SExposed::renderWindow)(window, monitor, now, decorate, mode, ignorePosition, standalone);
+    }
+
+    inline bool shouldBlur(PHLWINDOW window) {
+        return (g_pHyprRenderer.get()->*static_cast<bool (Render::IHyprRenderer::*)(PHLWINDOW)>(&SExposed::shouldBlur))(window);
+    }
+}

--- a/Window.cpp
+++ b/Window.cpp
@@ -216,6 +216,32 @@ static void roundStandaloneWindowPassElements(const PHLWINDOW& window, PHLMONITO
     }
 }
 
+// Hyprland 0.55's drawSurface() scissors each surface to its un-modified texture
+// box. Overview thumbnails are positioned by a SCALE+TRANSLATE renderModif that
+// only moves the texture geometry, so without an explicit clipBox the scissor
+// stays anchored at the monitor's top-left corner and clips the thumbnail away.
+// Setting clipBox routes renderTextureInternal through its clip branch, which
+// scissors to the full monitor instead — restoring the pre-0.55 behaviour.
+static void clipStandaloneWindowSurfaces(PHLMONITOR monitor, size_t firstElement) {
+    if (!monitor)
+        return;
+
+    const CBox clipBox = {{}, monitor->m_transformedSize};
+
+    auto& passElements = g_pHyprRenderer->m_renderPass.m_passElements;
+    for (size_t i = firstElement; i < passElements.size(); ++i) {
+        const auto& passElement = passElements[i];
+        if (!passElement || !passElement->element)
+            continue;
+
+        auto* surfacePassElement = dynamic_cast<CSurfacePassElement*>(passElement->element.get());
+        if (!surfacePassElement)
+            continue;
+
+        surfacePassElement->m_data.clipBox = clipBox;
+    }
+}
+
 static bool isOverviewHyprbarDecoration(IHyprWindowDecoration* decoration) {
     return decoration && decoration->getDecorationType() == DECORATION_CUSTOM && decoration->getDisplayName() == "Hyprbar";
 }
@@ -744,6 +770,7 @@ void renderOverviewWindow(const SRenderParams& params) {
     g_pHyprRenderer->m_renderPass.add(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{.renderModif = modif}));
     const auto firstWindowPassElement = g_pHyprRenderer->m_renderPass.m_passElements.size();
     ScrollOverview::RendererAccess::renderWindow(params.window, params.monitor, params.now, true, RENDER_PASS_ALL, true, true);
+    clipStandaloneWindowSurfaces(params.monitor, firstWindowPassElement);
     if (!fullscreen)
         roundStandaloneWindowPassElements(params.window, params.monitor, params.renderScale, firstWindowPassElement);
     g_pHyprRenderer->m_renderPass.add(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{.renderModif = SRenderModifData{}}));

--- a/Window.cpp
+++ b/Window.cpp
@@ -22,10 +22,15 @@
 #include <hyprland/src/render/pass/SurfacePassElement.hpp>
 #include <hyprland/src/render/decorations/CHyprGroupBarDecoration.hpp>
 #include <hyprland/src/render/decorations/DecorationPositioner.hpp>
+#include <hyprland/src/render/gl/GLTexture.hpp>
 #include <hyprutils/utils/ScopeGuard.hpp>
 #undef private
 #include "OverviewPassElement.hpp"
 #include "OverviewRender.hpp"
+#include "RendererAccess.hpp"
+
+using Render::SRenderModifData;
+using enum Render::eRenderPassMode;
 
 namespace OverviewWindow {
 namespace {
@@ -62,7 +67,7 @@ struct SHyprbarButtonMirror {
     CHyprColor   bgcol   = CHyprColor(0, 0, 0, 0);
     float        size    = 10.F;
     std::string  icon    = "";
-    SP<CTexture> iconTex = makeShared<CTexture>();
+    SP<Render::GL::CGLTexture> iconTex = makeShared<Render::GL::CGLTexture>();
 };
 
 struct SHyprbarGlobalStateMirror {
@@ -368,7 +373,7 @@ static void renderOverviewHyprbarDecoration(SOverviewCustomDecorationRenderState
             previousButtonSizes.push_back(button.size);
             button.size *= metrics.renderScale;
             if (button.iconTex && button.iconTex->m_texID != 0)
-                button.iconTex->destroyTexture();
+                button.iconTex.reset();
         }
     }
 
@@ -400,7 +405,7 @@ static void renderOverviewHyprbarDecoration(SOverviewCustomDecorationRenderState
             for (size_t i = 0; i < previousButtonSizes.size() && i < HYPRBARGLOBALSTATE->buttons.size(); ++i) {
                 HYPRBARGLOBALSTATE->buttons[i].size = previousButtonSizes[i];
                 if (HYPRBARGLOBALSTATE->buttons[i].iconTex && HYPRBARGLOBALSTATE->buttons[i].iconTex->m_texID != 0)
-                    HYPRBARGLOBALSTATE->buttons[i].iconTex->destroyTexture();
+                    HYPRBARGLOBALSTATE->buttons[i].iconTex.reset();
             }
         }
         return;
@@ -441,7 +446,7 @@ static void renderOverviewHyprbarDecoration(SOverviewCustomDecorationRenderState
             for (size_t i = 0; i < previousButtonSizes.size() && i < HYPRBARGLOBALSTATE->buttons.size(); ++i) {
                 HYPRBARGLOBALSTATE->buttons[i].size = previousButtonSizes[i];
                 if (HYPRBARGLOBALSTATE->buttons[i].iconTex && HYPRBARGLOBALSTATE->buttons[i].iconTex->m_texID != 0)
-                    HYPRBARGLOBALSTATE->buttons[i].iconTex->destroyTexture();
+                    HYPRBARGLOBALSTATE->buttons[i].iconTex.reset();
             }
         }
     });
@@ -454,7 +459,6 @@ static void renderOverviewWindowShadow(PHLMONITOR monitor, const PHLWINDOW& wind
     static auto PSHADOWS            = CConfigValue<Hyprlang::INT>("decoration:shadow:enabled");
     static auto PSHADOWSIZE         = CConfigValue<Hyprlang::INT>("decoration:shadow:range");
     static auto PSHADOWSHARP        = CConfigValue<Hyprlang::INT>("decoration:shadow:sharp");
-    static auto PSHADOWIGNOREWINDOW = CConfigValue<Hyprlang::INT>("decoration:shadow:ignore_window");
     static auto PSHADOWSCALE        = CConfigValue<Hyprlang::FLOAT>("decoration:shadow:scale");
     static auto PSHADOWOFFSET       = CConfigValue<Hyprlang::VEC2>("decoration:shadow:offset");
     static auto PSHADOWCOL          = CConfigValue<Hyprlang::INT>("decoration:shadow:color");
@@ -494,7 +498,7 @@ static void renderOverviewWindowShadow(PHLMONITOR monitor, const PHLWINDOW& wind
     data.range         = rangePx;
     data.color         = shadowColor;
     data.alpha         = metrics.targetOpacity;
-    data.ignoreWindow  = *PSHADOWIGNOREWINDOW;
+    data.ignoreWindow  = true; // decoration:shadow:ignore_window removed in Hyprland 0.55, defaults to enabled
     data.sharp         = *PSHADOWSHARP;
     g_pHyprRenderer->m_renderPass.add(makeUnique<COverviewShadowPassElement>(data));
 }
@@ -506,10 +510,10 @@ static void renderOverviewWindowBorder(PHLMONITOR monitor, const PHLWINDOW& wind
     if (metrics.borderSize <= 0.F)
         return;
 
-    static auto PACTIVECOL   = CConfigValue<Hyprlang::CUSTOMTYPE>("general:col.active_border");
-    static auto PINACTIVECOL = CConfigValue<Hyprlang::CUSTOMTYPE>("general:col.inactive_border");
-    auto* const ACTIVECOL    = reinterpret_cast<CGradientValueData*>((PACTIVECOL.ptr())->getData());
-    auto* const INACTIVECOL  = reinterpret_cast<CGradientValueData*>((PINACTIVECOL.ptr())->getData());
+    static auto PACTIVECOL   = CConfigValue<Config::IComplexConfigValue>("general:col.active_border");
+    static auto PINACTIVECOL = CConfigValue<Config::IComplexConfigValue>("general:col.inactive_border");
+    auto* const ACTIVECOL    = reinterpret_cast<Config::CGradientValueData*>(PACTIVECOL.ptr());
+    auto* const INACTIVECOL  = reinterpret_cast<Config::CGradientValueData*>(PINACTIVECOL.ptr());
 
     const auto& grad             = selected ? window->m_ruleApplicator->activeBorderColor().valueOr(*ACTIVECOL) : window->m_ruleApplicator->inactiveBorderColor().valueOr(*INACTIVECOL);
 
@@ -540,18 +544,18 @@ static void renderOverviewGroupTabIndicators(PHLMONITOR monitor, const PHLWINDOW
     static auto PROUNDINGPOWER          = CConfigValue<Hyprlang::FLOAT>("group:groupbar:rounding_power");
     static auto POUTERGAP               = CConfigValue<Hyprlang::INT>("group:groupbar:gaps_out");
     static auto PINNERGAP               = CConfigValue<Hyprlang::INT>("group:groupbar:gaps_in");
-    static auto PGROUPCOLACTIVE         = CConfigValue<Hyprlang::CUSTOMTYPE>("group:groupbar:col.active");
-    static auto PGROUPCOLINACTIVE       = CConfigValue<Hyprlang::CUSTOMTYPE>("group:groupbar:col.inactive");
-    static auto PGROUPCOLACTIVELOCKED   = CConfigValue<Hyprlang::CUSTOMTYPE>("group:groupbar:col.locked_active");
-    static auto PGROUPCOLINACTIVELOCKED = CConfigValue<Hyprlang::CUSTOMTYPE>("group:groupbar:col.locked_inactive");
+    static auto PGROUPCOLACTIVE         = CConfigValue<Config::IComplexConfigValue>("group:groupbar:col.active");
+    static auto PGROUPCOLINACTIVE       = CConfigValue<Config::IComplexConfigValue>("group:groupbar:col.inactive");
+    static auto PGROUPCOLACTIVELOCKED   = CConfigValue<Config::IComplexConfigValue>("group:groupbar:col.locked_active");
+    static auto PGROUPCOLINACTIVELOCKED = CConfigValue<Config::IComplexConfigValue>("group:groupbar:col.locked_inactive");
 
     if (*PINDICATORHEIGHT <= 0)
         return;
 
-    auto* const GROUPCOLACTIVE         = sc<CGradientValueData*>((PGROUPCOLACTIVE.ptr())->getData());
-    auto* const GROUPCOLINACTIVE       = sc<CGradientValueData*>((PGROUPCOLINACTIVE.ptr())->getData());
-    auto* const GROUPCOLACTIVELOCKED   = sc<CGradientValueData*>((PGROUPCOLACTIVELOCKED.ptr())->getData());
-    auto* const GROUPCOLINACTIVELOCKED = sc<CGradientValueData*>((PGROUPCOLINACTIVELOCKED.ptr())->getData());
+    auto* const GROUPCOLACTIVE         = sc<Config::CGradientValueData*>(PGROUPCOLACTIVE.ptr());
+    auto* const GROUPCOLINACTIVE       = sc<Config::CGradientValueData*>(PGROUPCOLINACTIVE.ptr());
+    auto* const GROUPCOLACTIVELOCKED   = sc<Config::CGradientValueData*>(PGROUPCOLACTIVELOCKED.ptr());
+    auto* const GROUPCOLINACTIVELOCKED = sc<Config::CGradientValueData*>(PGROUPCOLINACTIVELOCKED.ptr());
 
     const bool  groupLocked  = window->m_group->locked() || g_pKeybindManager->m_groupsLocked;
     const auto* colActive    = groupLocked ? GROUPCOLACTIVELOCKED : GROUPCOLACTIVE;
@@ -688,7 +692,7 @@ static SOverviewCustomDecorationRenderState renderOverviewCustomDecorations(PHLM
 } // namespace
 
 bool shouldBlurBackground(const PHLWINDOW& window) {
-    return window && g_pHyprRenderer->shouldBlur(window);
+    return window && ScrollOverview::RendererAccess::shouldBlur(window);
 }
 
 bool shouldUsePrecomputedBlur(const PHLWINDOW& window) {
@@ -721,7 +725,7 @@ void renderOverviewWindow(const SRenderParams& params) {
     if (shouldBlurBg) {
         OverviewRender::flushPass(params.monitor);
 
-        const float blurAlpha     = std::sqrt(params.window->m_alpha->value());
+        const float blurAlpha     = std::sqrt(params.window->alphaValue(Desktop::View::WINDOW_ALPHA_FADE));
         const int   blurRounding  = fullscreen ? 0 : sc<int>(std::round(getHyprlandDecorationRounding() * metrics.pxScale));
         const float roundingPower = fullscreen ? 2.F : getHyprlandDecorationRoundingPower();
         OverviewRender::renderBlur(params.monitor, params.windowBox, blurRounding, roundingPower, blurAlpha,
@@ -739,7 +743,7 @@ void renderOverviewWindow(const SRenderParams& params) {
 
     g_pHyprRenderer->m_renderPass.add(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{.renderModif = modif}));
     const auto firstWindowPassElement = g_pHyprRenderer->m_renderPass.m_passElements.size();
-    g_pHyprRenderer->renderWindow(params.window, params.monitor, params.now, true, RENDER_PASS_ALL, true, true);
+    ScrollOverview::RendererAccess::renderWindow(params.window, params.monitor, params.now, true, RENDER_PASS_ALL, true, true);
     if (!fullscreen)
         roundStandaloneWindowPassElements(params.window, params.monitor, params.renderScale, firstWindowPassElement);
     g_pHyprRenderer->m_renderPass.add(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{.renderModif = SRenderModifData{}}));

--- a/main.cpp
+++ b/main.cpp
@@ -339,7 +339,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 
     g_pScrollRenderWorkspaceHook = HyprlandAPI::createFunctionHook(
         SCROLLOVERVIEW_HANDLE,
-        findFnOrThrow("renderWorkspace", "CHyprRenderer::renderWorkspace("),
+        findFnOrThrow("renderWorkspace", "Render::IHyprRenderer::renderWorkspace("),
         (void*)hkRenderWorkspace);
 
     g_pScrollScheduleFrameHook = HyprlandAPI::createFunctionHook(
@@ -349,12 +349,12 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 
     g_pScrollDamageSurfaceHook = HyprlandAPI::createFunctionHook(
         SCROLLOVERVIEW_HANDLE,
-        findFnOrThrow("damageSurface", "CHyprRenderer::damageSurface("),
+        findFnOrThrow("damageSurface", "Render::IHyprRenderer::damageSurface("),
         (void*)hkDamageSurface);
 
     g_pScrollSendFrameEventsHook = HyprlandAPI::createFunctionHook(
         SCROLLOVERVIEW_HANDLE,
-        findFnOrThrow("sendFrameEventsToWorkspace", "CHyprRenderer::sendFrameEventsToWorkspace("),
+        findFnOrThrow("sendFrameEventsToWorkspace", "Render::IHyprRenderer::sendFrameEventsToWorkspace("),
         (void*)hkSendFrameEventsToWorkspace);
 
     g_pScrollSurfaceFrameHook = HyprlandAPI::createFunctionHook(
@@ -405,5 +405,5 @@ APICALL EXPORT void PLUGIN_EXIT() {
     g_pScrollOverview.reset();
     disableScrollOverviewHooks();
 
-    g_pConfigManager->reload(); // we need to reload now to clear all the gestures
+    Config::mgr()->reload(); // we need to reload now to clear all the gestures
 }

--- a/scrollOverview.cpp
+++ b/scrollOverview.cpp
@@ -13,6 +13,7 @@
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/config/ConfigValue.hpp>
 #include <hyprland/src/config/ConfigManager.hpp>
+#include <hyprland/src/config/shared/animation/AnimationTree.hpp>
 #include <hyprland/src/event/EventBus.hpp>
 #include <hyprland/src/managers/animation/AnimationManager.hpp>
 #include <hyprland/src/managers/animation/DesktopAnimationManager.hpp>
@@ -37,7 +38,7 @@
 #include <hyprland/src/helpers/math/Math.hpp>
 #include <hyprland/src/helpers/time/Time.hpp>
 #include <hyprland/src/plugins/PluginSystem.hpp>
-#include <hyprland/src/config/ConfigDataValues.hpp>
+#include <hyprland/src/config/shared/complex/ComplexDataTypes.hpp>
 #include <hyprland/src/render/pass/BorderPassElement.hpp>
 #include <hyprland/src/render/pass/Pass.hpp>
 #include <hyprland/src/render/pass/PreBlurElement.hpp>
@@ -51,6 +52,11 @@
 #include "OverviewPassElement.hpp"
 #include "OverviewRender.hpp"
 #include "Window.hpp"
+#include "RendererAccess.hpp"
+
+using Render::GL::g_pHyprOpenGL;
+using Render::GL::CHyprOpenGLImpl;
+using Render::SRenderModifData;
 
 static void damageMonitor(WP<Hyprutils::Animation::CBaseAnimatedVariable> thisptr) {
     g_pScrollOverview->damage();
@@ -201,8 +207,9 @@ static bool windowHasOverviewAnimation(const PHLWINDOW& window) {
     if (!window)
         return false;
 
-    return window->m_realPosition->isBeingAnimated() || window->m_realSize->isBeingAnimated() || window->m_alpha->isBeingAnimated() ||
-        window->m_activeInactiveAlpha->isBeingAnimated() || window->m_movingFromWorkspaceAlpha->isBeingAnimated() || window->m_movingToWorkspaceAlpha->isBeingAnimated() ||
+    return window->m_realPosition->isBeingAnimated() || window->m_realSize->isBeingAnimated() || window->alpha(Desktop::View::WINDOW_ALPHA_FADE)->isBeingAnimated() ||
+        window->alpha(Desktop::View::WINDOW_ALPHA_ACTIVE)->isBeingAnimated() || window->alpha(Desktop::View::WINDOW_ALPHA_MOVE_FROM_WORKSPACE)->isBeingAnimated() ||
+        window->alpha(Desktop::View::WINDOW_ALPHA_MOVE_TO_WORKSPACE)->isBeingAnimated() ||
         window->m_borderFadeAnimationProgress->isBeingAnimated() || window->m_borderAngleAnimationProgress->isBeingAnimated() || window->m_dimPercent->isBeingAnimated() ||
         window->m_realShadowColor->isBeingAnimated();
 }
@@ -214,9 +221,9 @@ static bool layerHasOverviewAnimation(const PHLLS& layer) {
     return layer->m_realPosition->isBeingAnimated() || layer->m_realSize->isBeingAnimated() || layer->m_alpha->isBeingAnimated();
 }
 
-static CCssGapData getOverviewWindowHitboxGap() {
-    static auto PGAPSIN = CConfigValue<Hyprlang::CUSTOMTYPE>("general:gaps_in");
-    return *sc<CCssGapData*>((PGAPSIN.ptr())->getData());
+static Config::CCssGapData getOverviewWindowHitboxGap() {
+    static auto PGAPSIN = CConfigValue<Config::IComplexConfigValue>("general:gaps_in");
+    return *sc<Config::CCssGapData*>(PGAPSIN.ptr());
 }
 
 static CBox getOverviewWindowBox(const PHLWINDOW& window, PHLMONITOR monitor, float scale, const Vector2D& viewOffset, float yoff) {
@@ -538,12 +545,12 @@ static SOverviewShadowConfig getOverviewShadowConfig() {
 
     static auto* const* PGLOBALRANGE       = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(SCROLLOVERVIEW_HANDLE, "decoration:shadow:range")->getDataStaticPtr();
     static auto* const* PGLOBALRENDERPOWER = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(SCROLLOVERVIEW_HANDLE, "decoration:shadow:render_power")->getDataStaticPtr();
-    static auto* const* PGLOBALIGNORE      = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(SCROLLOVERVIEW_HANDLE, "decoration:shadow:ignore_window")->getDataStaticPtr();
     static auto* const* PGLOBALCOLOR       = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(SCROLLOVERVIEW_HANDLE, "decoration:shadow:color")->getDataStaticPtr();
 
     const int range       = **PRANGE >= 0 ? **PRANGE : **PGLOBALRANGE;
     const int renderPower = **PRENDERPOWER >= 0 ? **PRENDERPOWER : **PGLOBALRENDERPOWER;
-    const int ignore      = **PIGNORE >= 0 ? **PIGNORE : **PGLOBALIGNORE;
+    // decoration:shadow:ignore_window was removed in Hyprland 0.55; it now defaults to enabled.
+    const int ignore      = **PIGNORE >= 0 ? **PIGNORE : 1;
     const auto color      = **PCOLOR >= 0 ? **PCOLOR : **PGLOBALCOLOR;
 
     return {
@@ -785,12 +792,12 @@ static void moveOverviewTargetNextToWindow(const SP<Layout::ITarget>& target, co
 }
 
 CScrollOverview::~CScrollOverview() {
-    g_pHyprRenderer->makeEGLCurrent();
+    g_pHyprOpenGL->makeEGLCurrent();
     if (realtimePreviewTimer) {
         wl_event_source_remove(realtimePreviewTimer);
         realtimePreviewTimer = nullptr;
     }
-    backdropBlurFB.release();
+    backdropBlurFB->release();
     const auto MONITOR = pMonitor.lock();
     const auto WORKSPACE = MONITOR ? MONITOR->m_activeWorkspace : PHLWORKSPACE{};
     emitFullscreenVisibilityState(getOverviewFullscreenVisibilityWindow(WORKSPACE, Desktop::focusState()->window()), false);
@@ -800,7 +807,8 @@ CScrollOverview::~CScrollOverview() {
     restoreForcedLayerVisibility();
     images.clear(); // otherwise we get a vram leak
     Cursor::overrideController->unsetOverride(Cursor::CURSOR_OVERRIDE_SPECIAL_ACTION);
-    g_pHyprOpenGL->markBlurDirtyForMonitor(pMonitor.lock());
+    if (const auto MON = pMonitor.lock())
+        MON->m_blurFBDirty = true;
 }
 
 CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn_), swipe(swipe_) {
@@ -811,7 +819,7 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
     realtimePreviewTimer = wl_event_loop_add_timer(g_pCompositor->m_wlEventLoop, realtimePreviewTimerCallback, this);
     scheduleMinimumPreviewFrame();
 
-    const auto WINDOWSMOVECONFIG = g_pConfigManager->getAnimationPropertyConfig("windowsMove");
+    const auto WINDOWSMOVECONFIG = Config::animationTree()->getAnimationPropertyConfig("windowsMove");
     const auto WINDOWSMOVEVALUES = WINDOWSMOVECONFIG && WINDOWSMOVECONFIG->pValues ? WINDOWSMOVECONFIG->pValues.lock() : WINDOWSMOVECONFIG;
     if (!g_pAnimationManager->bezierExists(OVERVIEW_INSERT_FADE_BEZIER))
         g_pAnimationManager->addBezierWithName(OVERVIEW_INSERT_FADE_BEZIER, Vector2D{0.5, 0.0}, Vector2D{0.5, 0.0});
@@ -1179,7 +1187,7 @@ static void renderOverviewLayerLevel(PHLMONITOR monitor, uint32_t layer, const C
             LAYER->m_alpha->setValueAndWarp(previousAlpha * std::clamp(alpha, 0.F, 1.F));
         }
 
-        g_pHyprRenderer->renderLayer(LAYER, monitor, now);
+        ScrollOverview::RendererAccess::renderLayer(LAYER, monitor, now);
 
         if (MODULATEALPHA && LAYER->m_alpha)
             LAYER->m_alpha->setValueAndWarp(previousAlpha);
@@ -1200,13 +1208,13 @@ void CScrollOverview::renderGlobalWallpaper(PHLMONITOR monitor, const Time::stea
     if (!monitor)
         return;
 
-    g_pHyprRenderer->renderBackground(monitor);
+    ScrollOverview::RendererAccess::renderBackground(monitor);
 
     for (auto const& ls : monitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND]) {
         if (!Desktop::View::validMapped(ls.lock()))
             continue;
 
-        g_pHyprRenderer->renderLayer(ls.lock(), monitor, now);
+        ScrollOverview::RendererAccess::renderLayer(ls.lock(), monitor, now);
     }
 }
 
@@ -1220,25 +1228,25 @@ void CScrollOverview::updateBackdropBlurCache(PHLMONITOR monitor, int wallpaperM
     }
 
     const auto FBFORMAT = getOverviewFramebufferFormat(monitor);
-    if (!backdropBlurFB.isAllocated() || backdropBlurFB.m_size != monitor->m_pixelSize || backdropBlurFB.m_drmFormat != FBFORMAT) {
-        backdropBlurFB.release();
-        backdropBlurFB.alloc(monitor->m_pixelSize.x, monitor->m_pixelSize.y, FBFORMAT);
+    if (!backdropBlurFB->isAllocated() || backdropBlurFB->m_size != monitor->m_pixelSize || backdropBlurFB->m_drmFormat != FBFORMAT) {
+        backdropBlurFB->release();
+        backdropBlurFB->alloc(monitor->m_pixelSize.x, monitor->m_pixelSize.y, FBFORMAT);
         backdropBlurDirty = true;
     }
 
     if (!backdropBlurDirty)
         return;
 
-    auto* const SAVEDFB = g_pHyprOpenGL->m_renderData.currentFB;
-    backdropBlurFB.bind();
-    g_pHyprOpenGL->m_renderData.currentFB = &backdropBlurFB;
+    const auto SAVEDFB = g_pHyprRenderer->m_renderData.currentFB;
+    backdropBlurFB->bind();
+    g_pHyprRenderer->m_renderData.currentFB = backdropBlurFB;
     auto restoreFB = Hyprutils::Utils::CScopeGuard([SAVEDFB] {
         if (SAVEDFB)
             SAVEDFB->bind();
 
-        g_pHyprOpenGL->m_renderData.currentFB = SAVEDFB;
+        g_pHyprRenderer->m_renderData.currentFB = SAVEDFB;
     });
-    g_pHyprOpenGL->clear(CHyprColor{0.F, 0.F, 0.F, 1.F});
+    g_pHyprRenderer->draw(CClearPassElement::SClearData{.color = CHyprColor{0.F, 0.F, 0.F, 1.F}});
 
     renderGlobalWallpaper(monitor, now);
 
@@ -1249,11 +1257,11 @@ void CScrollOverview::updateBackdropBlurCache(PHLMONITOR monitor, int wallpaperM
 }
 
 void CScrollOverview::renderBackdropBlurCache(PHLMONITOR monitor) {
-    if (!monitor || !backdropBlurFB.isAllocated() || !backdropBlurFB.getTexture())
+    if (!monitor || !backdropBlurFB->isAllocated() || !backdropBlurFB->getTexture())
         return;
 
     CRegion fullDamage{CBox{{}, monitor->m_transformedSize}};
-    const auto TEX = backdropBlurFB.getTexture();
+    const auto TEX = backdropBlurFB->getTexture();
     const auto SAVEDTRANSFORM = TEX->m_transform;
     TEX->m_transform = Math::wlTransformToHyprutils(Math::invertTransform(monitor->m_transform));
     auto restoreTransform = Hyprutils::Utils::CScopeGuard([TEX, SAVEDTRANSFORM] { TEX->m_transform = SAVEDTRANSFORM; });
@@ -3313,7 +3321,7 @@ void CScrollOverview::render() {
     } else if (WALLPAPERMODE == 0 || WALLPAPERMODE == 2) {
         renderGlobalWallpaper(MONITOR, NOW);
     } else
-        g_pHyprOpenGL->clear(CHyprColor{0.F, 0.F, 0.F, 1.F});
+        g_pHyprRenderer->draw(CClearPassElement::SClearData{.color = CHyprColor{0.F, 0.F, 0.F, 1.F}});
 
     Event::bus()->m_events.render.stage.emit(RENDER_POST_WALLPAPER);
 
@@ -3356,7 +3364,7 @@ void CScrollOverview::render() {
         if (!Desktop::View::validMapped(ls.lock()))
             continue;
 
-        g_pHyprRenderer->renderLayer(ls.lock(), MONITOR, NOW);
+        ScrollOverview::RendererAccess::renderLayer(ls.lock(), MONITOR, NOW);
     }
 
     sendOverviewFrameCallbacks(NOW);

--- a/scrollOverview.hpp
+++ b/scrollOverview.hpp
@@ -9,7 +9,7 @@
 #include <hyprland/src/event/EventBus.hpp>
 #include <hyprland/src/helpers/time/Time.hpp>
 #include <hyprland/src/layout/LayoutManager.hpp>
-#include <hyprland/src/render/Framebuffer.hpp>
+#include <hyprland/src/render/gl/GLFramebuffer.hpp>
 #include <chrono>
 #include <unordered_map>
 #include <vector>
@@ -110,7 +110,7 @@ class CScrollOverview : public IOverview {
     float  lastOverviewBlurScale    = 1.F;
     int    lastBackdropWallpaperMode = -1;
     Vector2D lastOverviewBlurViewOffset = Vector2D{};
-    CFramebuffer backdropBlurFB;
+    SP<Render::GL::CGLFramebuffer> backdropBlurFB = makeShared<Render::GL::CGLFramebuffer>();
 
     struct SWorkspaceImage {
         PHLWORKSPACE              pWorkspace;


### PR DESCRIPTION
## Summary

First-draft port of ScrollOverview to **Hyprland 0.55** (developed against 0.55.2,
commit `39d7e20`). On 0.55 the plugin previously failed to build, and once
building hit several runtime crashes plus a rendering regression. This branch
gets it building, loading, and rendering on 0.55.

**This is a draft / first cut** — please read the disclosures below before merging.

## What changed

0.55 reworked large parts of the renderer and config subsystems. This port
addresses each break:

- Renderer state (`m_renderData`) relocated from `g_pHyprOpenGL` to `g_pHyprRenderer`; the GL impl is now namespaced under `Render::GL::`.
- Several renderer entry points (`renderWindow`, `renderLayer`, `renderBackground`, `shouldBlur`) became `protected` — reached via a new `RendererAccess.hpp` (see the internal-API note below).
- `IPassElement` gained a pure-virtual `type()`; custom pass elements now declare `EK_CUSTOM`.
- Config types moved to the `Config::` namespace; `CConfigValue<Hyprlang::CUSTOMTYPE>` → `CConfigValue<Config::IComplexConfigValue>` (the old form dereferences the wrong pointer on 0.55 and crashes).
- `CFramebuffer` / `CTexture` → `Render::GL::CGLFramebuffer` / `CGLTexture`; blur path reworked (`blurMainFramebuffer` now returns a texture).
- `g_pConfigManager` removed → `Config::mgr()` / `Config::animationTree()`.
- Window alpha variables consolidated into `CMultiAVarContainer` accessors.
- `decoration:shadow:ignore_window` was removed in 0.55 (reading it null-derefs) — hardcoded to its new default.
- Function-hook symbol filters updated for the renamed `Render::IHyprRenderer`.
- **Overview window-surface clipping fix:** 0.55's `drawSurface()` scissors each surface to its *un-modified* texture box, so thumbnails positioned by a render-modif get clipped — rightmost thumbnails render empty, the bottom one short. Restored by setting `clipBox` on the standalone window surfaces.

## Internal-API usage — done the right way vs. still shimmed

ScrollOverview is inherently coupled to Hyprland internals — it hooks internal
renderer functions and reaches into renderer state. A deliberate goal of this
port was to drop shims wherever the language offers a legal alternative, and to
be explicit about what remains. The honest split:

**Done the right way (no shim):**

- **Protected renderer methods** (`renderWindow`, `renderLayer`, `renderBackground`, `shouldBlur`) — accessed via the new `RendererAccess.hpp`, a standards-compliant pointer-to-member helper. This **eliminates the previous `#define protected public` shim**: a derived class may legally form a pointer-to-member of a *protected* base member, and calling through it performs no access check.
- **Config values, config keywords, dispatchers, function-hook registration, notifications** — all go through the public `HyprlandAPI::*` plugin API (~55 call sites), as before.

**Still internal / shimmed:**

- **`#define private public`** remains in all 4 main source files. It is required for direct access to *private* Hyprland members (`m_renderData`, `m_renderPass`, `m_passElements`, …). Unlike the protected case, the pointer-to-member technique does **not** work for private members — there is no standards-compliant equivalent — so this shim is unavoidable here short of upstream changes.
- **7 function hooks** target internal renderer symbols (`renderWorkspace`, `damageSurface`, …). The hook *mechanism* is the public `HyprlandAPI::createFunctionHook`, but the hooked functions are internal — intrinsic to what this plugin does.
- The clipping fix manipulates render-pass internals (`m_passElements`, surface `clipBox`); there is no public API for that.

**Net:** of the two compiler-level shims, one (`#define protected public`) was
removed; one (`#define private public`) remains because C++ offers no legal
alternative for private members. The rest of the diff is straight use of the new
0.55 API surface. Reducing the remaining internal coupling further is intent for
follow-up work, but most of it is intrinsic to an overview plugin and would need
additional upstream plugin-API surface to remove — so the cleanup ceiling here is
limited without changes on the Hyprland side.

## ⚠️ Disclosures — please read before merging

- **This branch is fully agent-generated** (Claude).
- It **builds cleanly** against Hyprland 0.55.2 and is **functional in a VM** — verified by running the overview in an isolated, headless Hyprland 0.55.2 VM, including an A/B test of the clipping fix.
- It has **not been thoroughly audited for accuracy.** Every change should be treated as needing human review. This is offered as a starting point, not a finished, vetted port.

## Known limitations / not yet addressed

- **Overview shadows do not render on 0.55.** The custom shadow pass element still uses the old `draw(const CRegion&)` signature; 0.55 changed `IPassElement::draw()` to a no-argument, sub-element-returning method, so the shadow-drawing code is never invoked. This compiles silently and is masked in practice because shadows default to off. A proper fix should decompose the custom element into standard pass elements (`CShadowPassElement` / `CRectPassElement`). Not done in this draft.
- `CScrollOverviewPassElement` appears to be dead code (never instantiated; its `fullRender()` is empty) — left untouched.
- The backdrop-blur cache path builds but was not specifically exercised at runtime.

## Overview on Hyprland 0.55

ScrollOverview running on Hyprland 0.55 with this branch — window thumbnails
render their surface content (clipping fix applied):

<img width="3669" height="2070" alt="screenshot-2026-05-20_20-33-29" src="https://github.com/user-attachments/assets/8b3fafb4-5d0f-447d-8baa-7870d7c9a9bd" />


## Testing

- Built against Hyprland 0.55.2 (`39d7e209c79d451efab1b21151d5938289da838d`).
- Runtime-tested in an isolated Hyprland 0.55.2 VM: the plugin loads, the overview opens/closes, and windows render. The clipping fix was A/B-verified — an un-fixed build reproduces the empty thumbnails, the fixed build renders full content.
- Not yet tested on real hardware or a full desktop session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
