### PR TITLE
Allow mouse wheel shortcuts with modifiers to work correctly

### DIFF
--- a/scrollOverview.cpp
+++ b/scrollOverview.cpp
@@ -1058,6 +1058,12 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
         if (closing)
             return;
 
+        const auto MODS = g_pInputManager->getModsFromAllKBs() &
+                          (HL_MODIFIER_SHIFT | HL_MODIFIER_META | HL_MODIFIER_CTRL | HL_MODIFIER_ALT);
+
+        if (MODS != 0)
+            return;
+
         info.cancelled = true;
         moveViewportWorkspace(e.delta > 0);
     };


### PR DESCRIPTION
Fix `modifier + mouse_up/mouse_down` shortcuts being intercepted by the overview