### PR TITLE
Trackpad scroll/gesture improvements

### DIFF
--- a/Config.cpp
+++ b/Config.cpp
@@ -16,6 +16,7 @@ extern "C" {
 namespace {
 
 ScrollOverview::Config::TOverviewDispatcher g_overviewDispatcher = nullptr;
+ScrollOverview::Config::TGestureRegistrar   g_gestureRegistrar   = nullptr;
 
 bool isOverviewArgValid(const std::string_view arg) {
     return arg == "toggle" || arg == "select" || arg == "on" || arg == "enable" || arg == "off" || arg == "disable";
@@ -134,17 +135,62 @@ int configureLua(lua_State* L) {
     return 0;
 }
 
+int gestureLua(lua_State* L) {
+    if (!g_gestureRegistrar)
+        return luaL_error(L, "gesture: registrar is not registered");
+
+    if (!lua_istable(L, 1))
+        return luaL_error(L, "gesture: expected a table, e.g. { fingers = 3, direction = \"up\" }");
+
+    lua_getfield(L, 1, "fingers");
+    if (!lua_isnumber(L, -1))
+        return luaL_error(L, "gesture: 'fingers' (number) is required");
+    const size_t FINGERS = sc<size_t>(lua_tointeger(L, -1));
+    lua_pop(L, 1);
+
+    lua_getfield(L, 1, "direction");
+    if (!lua_isstring(L, -1))
+        return luaL_error(L, "gesture: 'direction' (string) is required");
+    const std::string DIRECTION = lua_tostring(L, -1);
+    lua_pop(L, 1);
+
+    lua_getfield(L, 1, "action");
+    const std::string ACTION = lua_isstring(L, -1) ? lua_tostring(L, -1) : "overview";
+    lua_pop(L, 1);
+
+    // accept either "mods" or "mod"
+    lua_getfield(L, 1, "mods");
+    if (lua_isnil(L, -1)) {
+        lua_pop(L, 1);
+        lua_getfield(L, 1, "mod");
+    }
+    const std::string MODS = lua_isstring(L, -1) ? lua_tostring(L, -1) : "";
+    lua_pop(L, 1);
+
+    lua_getfield(L, 1, "scale");
+    const float SCALE = lua_isnumber(L, -1) ? sc<float>(lua_tonumber(L, -1)) : 1.F;
+    lua_pop(L, 1);
+
+    const auto result = g_gestureRegistrar(FINGERS, DIRECTION, ACTION, MODS, SCALE);
+    if (!result.success)
+        return luaL_error(L, "gesture: %s", result.error.c_str());
+
+    return 0;
+}
+
 }
 
 namespace ScrollOverview::Config {
 
-void registerLua(TOverviewDispatcher dispatcher) {
+void registerLua(TOverviewDispatcher dispatcher, TGestureRegistrar gestureRegistrar) {
     if (::Config::mgr()->type() != ::Config::CONFIG_LUA)
         return;
 
     g_overviewDispatcher = dispatcher;
+    g_gestureRegistrar   = gestureRegistrar;
     HyprlandAPI::addLuaFunction(SCROLLOVERVIEW_HANDLE, "scrolloverview", "overview", ::overviewLua);
     HyprlandAPI::addLuaFunction(SCROLLOVERVIEW_HANDLE, "scrolloverview", "configure", ::configureLua);
+    HyprlandAPI::addLuaFunction(SCROLLOVERVIEW_HANDLE, "scrolloverview", "gesture", ::gestureLua);
 }
 
 void registerLegacy() {
@@ -158,10 +204,8 @@ void registerLegacy() {
                                   makeShared<CIntValue>("plugin:scrolloverview:workspace_gap", "gap between overview workspaces", 0, SIntValueOptions{.min = 0}));
     HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE,
                                   makeShared<CStringValue>("plugin:scrolloverview:layout", "overview layout", Hyprlang::STRING{"vertical"}));
-    HyprlandAPI::addConfigValueV2(
-        SCROLLOVERVIEW_HANDLE,
-        makeShared<CIntValue>("plugin:scrolloverview:scroll_event_delay", "minimum delay (ms) between discrete scroll steps (wheel workspace nav and trackpad focus stepping)", 200,
-                              SIntValueOptions{.min = 0}));
+    HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE,
+                                  makeShared<CIntValue>("plugin:scrolloverview:scroll_event_delay", "minimum delay (ms) between discrete scroll steps (wheel workspace nav and trackpad focus stepping)", 200, SIntValueOptions{.min = 0}));
     HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE,
                                   makeShared<CIntValue>("plugin:scrolloverview:input:left_handed", "overview left handed mouse buttons, 2 follows input:left_handed", 2,
                                                         SIntValueOptions{.min = 0, .max = 2}));

--- a/Config.cpp
+++ b/Config.cpp
@@ -158,6 +158,10 @@ void registerLegacy() {
                                   makeShared<CIntValue>("plugin:scrolloverview:workspace_gap", "gap between overview workspaces", 0, SIntValueOptions{.min = 0}));
     HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE,
                                   makeShared<CStringValue>("plugin:scrolloverview:layout", "overview layout", Hyprlang::STRING{"vertical"}));
+    HyprlandAPI::addConfigValueV2(
+        SCROLLOVERVIEW_HANDLE,
+        makeShared<CIntValue>("plugin:scrolloverview:scroll_event_delay", "minimum delay (ms) between discrete scroll steps (wheel workspace nav and trackpad focus stepping)", 200,
+                              SIntValueOptions{.min = 0}));
     HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE,
                                   makeShared<CIntValue>("plugin:scrolloverview:wallpaper", "wallpaper mode", 0, SIntValueOptions{.min = 0, .max = 2}));
     HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE, makeShared<CBoolValue>("plugin:scrolloverview:blur", "blur the overview wallpaper", false));
@@ -186,6 +190,10 @@ int getWorkspaceGap() {
 ELayout getLayout() {
     const auto LAYOUT = getValue<std::string>("plugin:scrolloverview:layout");
     return LAYOUT == "horizontal" ? ELayout::HORIZONTAL : ELayout::VERTICAL;
+}
+
+int getScrollEventDelay() {
+    return std::max<int>(0, getValue<int>("plugin:scrolloverview:scroll_event_delay"));
 }
 
 int getWallpaperMode() {

--- a/Config.cpp
+++ b/Config.cpp
@@ -143,8 +143,8 @@ int gestureLua(lua_State* L) {
         return luaL_error(L, "gesture: expected a table, e.g. { fingers = 3, direction = \"up\" }");
 
     lua_getfield(L, 1, "fingers");
-    if (!lua_isnumber(L, -1))
-        return luaL_error(L, "gesture: 'fingers' (number) is required");
+    if (!lua_isinteger(L, -1))
+        return luaL_error(L, "gesture: 'fingers' (integer) is required");
     const size_t FINGERS = sc<size_t>(lua_tointeger(L, -1));
     lua_pop(L, 1);
 
@@ -171,7 +171,11 @@ int gestureLua(lua_State* L) {
     const float SCALE = lua_isnumber(L, -1) ? sc<float>(lua_tonumber(L, -1)) : 1.F;
     lua_pop(L, 1);
 
-    const auto result = g_gestureRegistrar(FINGERS, DIRECTION, ACTION, MODS, SCALE);
+    lua_getfield(L, 1, "disable_inhibit");
+    const bool DISABLE_INHIBIT = lua_toboolean(L, -1);
+    lua_pop(L, 1);
+
+    const auto result = g_gestureRegistrar(FINGERS, DIRECTION, ACTION, MODS, SCALE, DISABLE_INHIBIT);
     if (!result.success)
         return luaL_error(L, "gesture: %s", result.error.c_str());
 
@@ -206,15 +210,6 @@ void registerLegacy() {
                                   makeShared<CStringValue>("plugin:scrolloverview:layout", "overview layout", Hyprlang::STRING{"vertical"}));
     HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE,
                                   makeShared<CIntValue>("plugin:scrolloverview:scroll_event_delay", "minimum delay (ms) between discrete scroll steps (wheel workspace nav and trackpad focus stepping)", 200, SIntValueOptions{.min = 0}));
-    HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE,
-                                  makeShared<CIntValue>("plugin:scrolloverview:input:left_handed", "overview left handed mouse buttons, 2 follows input:left_handed", 2,
-                                                        SIntValueOptions{.min = 0, .max = 2}));
-    HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE,
-                                  makeShared<CIntValue>("plugin:scrolloverview:input:scrolling_mode", "overview mouse wheel behavior", 0,
-                                                        SIntValueOptions{.min = 0, .max = 3}));
-    HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE,
-                                  makeShared<CIntValue>("plugin:scrolloverview:input:drag_mode", "overview mouse drag behavior", 0,
-                                                        SIntValueOptions{.min = 0, .max = 1}));
     HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE,
                                   makeShared<CIntValue>("plugin:scrolloverview:input:left_handed", "overview left handed mouse buttons, 2 follows input:left_handed", 2,
                                                         SIntValueOptions{.min = 0, .max = 2}));

--- a/Config.hpp
+++ b/Config.hpp
@@ -71,6 +71,7 @@ int          getGestureDistance();
 float        getScale();
 int          getWorkspaceGap();
 ELayout      getLayout();
+int          getScrollEventDelay();
 int          getWallpaperMode();
 bool         getBlur();
 ::Config::CCssGapData getCssGapData(const std::string& name);

--- a/Config.hpp
+++ b/Config.hpp
@@ -14,6 +14,7 @@
 namespace ScrollOverview::Config {
 
 using TOverviewDispatcher = SDispatchResult (*)(std::string);
+using TGestureRegistrar   = SDispatchResult (*)(size_t fingerCount, const std::string& direction, const std::string& action, const std::string& mods, float deltaScale);
 
 enum class ELayout {
     VERTICAL,
@@ -25,7 +26,7 @@ enum class EScrollAction {
     COLUMN,
 };
 
-void registerLua(TOverviewDispatcher dispatcher);
+void registerLua(TOverviewDispatcher dispatcher, TGestureRegistrar gestureRegistrar);
 void registerLegacy();
 
 template <typename T>

--- a/Config.hpp
+++ b/Config.hpp
@@ -14,7 +14,8 @@
 namespace ScrollOverview::Config {
 
 using TOverviewDispatcher = SDispatchResult (*)(std::string);
-using TGestureRegistrar   = SDispatchResult (*)(size_t fingerCount, const std::string& direction, const std::string& action, const std::string& mods, float deltaScale);
+using TGestureRegistrar   = SDispatchResult (*)(size_t fingerCount, const std::string& direction, const std::string& action, const std::string& mods, float deltaScale,
+                                                bool disableInhibit);
 
 enum class ELayout {
     VERTICAL,

--- a/OverviewGesture.cpp
+++ b/OverviewGesture.cpp
@@ -16,7 +16,7 @@ void COverviewGesture::begin(const ITrackpadGesture::STrackpadGestureBegin& e) {
         if (!ensureScrollOverviewHooks())
             return;
 
-        g_pScrollOverview = makeShared<CScrollOverview>(Desktop::focusState()->monitor()->m_activeWorkspace);
+        g_pScrollOverview = makeShared<CScrollOverview>(Desktop::focusState()->monitor()->m_activeWorkspace, true);
     } else {
         g_pScrollOverview->selectHoveredWorkspace();
         g_pScrollOverview->setClosing(true);
@@ -24,6 +24,9 @@ void COverviewGesture::begin(const ITrackpadGesture::STrackpadGestureBegin& e) {
 }
 
 void COverviewGesture::update(const ITrackpadGesture::STrackpadGestureUpdate& e) {
+    if (!g_pScrollOverview)
+        return;
+
     if (m_firstUpdate) {
         m_firstUpdate = false;
         return;
@@ -38,6 +41,10 @@ void COverviewGesture::update(const ITrackpadGesture::STrackpadGestureUpdate& e)
 }
 
 void COverviewGesture::end(const ITrackpadGesture::STrackpadGestureEnd& e) {
-    g_pScrollOverview->onSwipeEnd();
-    g_pScrollOverview->resetSwipe();
+    if (g_pScrollOverview)
+        g_pScrollOverview->onSwipeEnd();
+
+    //re-check since onSwipeEnd can call close and de-ref g_pScrollOverview
+    if (g_pScrollOverview)
+        g_pScrollOverview->resetSwipe();
 }

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ In Lua, `shadow.color` must be an integer color value. The Hyprlang-only
 | property         | type   | description                                                            | default |
 | ---------------- | ------ | ---------------------------------------------------------------------- | ------- |
 | gesture_distance | number | how far is the max for the gesture                                     | `200`   |
+| scroll_event_delay | number | in ms, delay between scroll events (to prevent multiple activation)    | `200`   |
 | scale            | float  | overview scale, [0.1 - 0.9]                                            | `0.5`   |
 | workspace_gap    | number | gap between visible workspaces in the overview, in pixels              | `0`     |
 | layout           | string | overview layout: `vertical` or `horizontal`                           | `vertical` |
@@ -103,12 +104,6 @@ Controls the shadow around each workspace card. `enabled` defaults to `false`; a
 | range | int | shadow range in layout px | `decoration:shadow:range` |
 | render_power | int | shadow falloff power | `decoration:shadow:render_power` |
 | color | color | shadow color | `decoration:shadow:color` |
-
-### Keywords
-
-| name                   | description                                                             | arguments       |
-| ---------------------- | ----------------------------------------------------------------------- | --------------- |
-| scrolloverview-gesture | same as gesture, but for ScrollOverview gestures. Supports: `overview`. | Same as gesture |
 
 ### Binding
 
@@ -138,6 +133,42 @@ end)
 `hl.plugin.scrolloverview.overview("toggle")` returns a dispatcher function
 accepted by `hl.dispatch()` and binds. When called from inside a Lua keybind
 callback, it dispatches immediately.
+
+### Gesture
+
+The overview can be opened/closed with a trackpad swipe gesture. Configure it as follows.
+
+#### Hyprlang
+
+```ini
+# hyprland.conf
+scrolloverview-gesture = 3, up, overview        # 3-finger up swipe
+scrolloverview-gesture = 4, up, overview, mod:SUPER, scale:1.5
+scrolloverview-gesture = 3, up, unset           # remove a previously set gesture
+```
+
+| name                   | description                                                             | arguments       |
+| ---------------------- | ----------------------------------------------------------------------- | --------------- |
+| scrolloverview-gesture | same as gesture, but for ScrollOverview gestures. Supports: `overview`. | Same as gesture |
+
+#### Lua
+
+Call `hl.plugin.scrolloverview.gesture{ ... }` from your Lua config.
+
+```lua
+-- hyprland.lua
+hl.plugin.scrolloverview.gesture({ fingers = 3, direction = "vertical" })
+hl.plugin.scrolloverview.gesture({ fingers = 4, direction = "vertical", mod = "SUPER", scale = 1.5 })
+hl.plugin.scrolloverview.gesture({ fingers = 3, direction = "vertical", action = "unset" })
+```
+
+| field     | type   | description                                              | default    |
+| --------- | ------ | -------------------------------------------------------- | ---------- |
+| fingers   | number | finger count (2–9)                                       | required   |
+| direction | string | swipe direction (`up`, `down`, `left`, `right`, …)       | required   |
+| action    | string | `overview` to register, `unset` to remove                | `overview` |
+| mod       | string | modifier mask held during the gesture (e.g. `SUPER`)     | none       |
+| scale     | number | gesture delta scale, `[0.1 – 10]`                        | `1.0`      |
 
 ### Other Lua Examples
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ The overview can be opened/closed with a trackpad swipe gesture. Configure it as
 # hyprland.conf
 scrolloverview-gesture = 3, up, overview        # 3-finger up swipe
 scrolloverview-gesture = 4, up, overview, mod:SUPER, scale:1.5
+scrolloverview-gesture = 4, up, overview, disable_inhibit   # fire even when an app inhibits gestures
 scrolloverview-gesture = 3, up, unset           # remove a previously set gesture
 ```
 
@@ -159,6 +160,7 @@ Call `hl.plugin.scrolloverview.gesture{ ... }` from your Lua config.
 -- hyprland.lua
 hl.plugin.scrolloverview.gesture({ fingers = 3, direction = "vertical" })
 hl.plugin.scrolloverview.gesture({ fingers = 4, direction = "vertical", mod = "SUPER", scale = 1.5 })
+hl.plugin.scrolloverview.gesture({ fingers = 4, direction = "vertical", disable_inhibit = true })
 hl.plugin.scrolloverview.gesture({ fingers = 3, direction = "vertical", action = "unset" })
 ```
 
@@ -169,6 +171,7 @@ hl.plugin.scrolloverview.gesture({ fingers = 3, direction = "vertical", action =
 | action    | string | `overview` to register, `unset` to remove                | `overview` |
 | mod       | string | modifier mask held during the gesture (e.g. `SUPER`)     | none       |
 | scale     | number | gesture delta scale, `[0.1 – 10]`                        | `1.0`      |
+| disable_inhibit | bool | fire the gesture even when an app inhibits gestures   | `false`    |
 
 ### Other Lua Examples
 

--- a/main.cpp
+++ b/main.cpp
@@ -258,6 +258,46 @@ static void* findFnOrThrow(const std::string& name, std::initializer_list<std::s
     return matches[0].address;
 }
 
+// shared core: register / unregister the overview trackpad gesture. used by both the hyprlang
+// keyword and the Lua `scrolloverview.gesture` function so both configure the same gesture system.
+static std::expected<void, std::string> applyOverviewGesture(size_t fingerCount, eTrackpadGestureDirection direction, const std::string& action, uint32_t modMask,
+                                                             float deltaScale) {
+    if (fingerCount <= 1 || fingerCount >= 10)
+        return std::unexpected(std::format("Invalid value {} for finger count", fingerCount));
+
+    if (direction == TRACKPAD_GESTURE_DIR_NONE)
+        return std::unexpected("Invalid direction");
+
+    if (action == "overview")
+        return g_pTrackpadGestures->addGesture(makeUnique<COverviewGesture>(), fingerCount, direction, modMask, deltaScale, false);
+
+    if (action == "unset")
+        return g_pTrackpadGestures->removeGesture(fingerCount, direction, modMask, deltaScale, false);
+
+    return std::unexpected(std::format("Invalid gesture: {}", action));
+}
+
+// Lua-facing registrar (scrolloverview.gesture). takes the direction/mods as strings and resolves
+// them the same way the keyword does, then defers to applyOverviewGesture.
+static SDispatchResult onRegisterOverviewGesture(size_t fingerCount, const std::string& directionStr, const std::string& action, const std::string& mods, float deltaScale) {
+    if (g_unloading)
+        return {};
+
+    const auto direction = g_pTrackpadGestures->dirForString(directionStr);
+    if (direction == TRACKPAD_GESTURE_DIR_NONE)
+        return {.success = false, .error = std::format("Invalid direction: {}", directionStr)};
+
+    uint32_t modMask = 0;
+    if (!mods.empty() && g_pKeybindManager)
+        modMask = g_pKeybindManager->stringToModMask(mods);
+
+    const auto res = applyOverviewGesture(fingerCount, direction, action, modMask, std::clamp(deltaScale, 0.1F, 10.F));
+    if (!res)
+        return {.success = false, .error = res.error()};
+
+    return {};
+}
+
 static Hyprlang::CParseResult overviewGestureKeyword(const char* LHS, const char* RHS) {
     Hyprlang::CParseResult result;
 
@@ -267,7 +307,6 @@ static Hyprlang::CParseResult overviewGestureKeyword(const char* LHS, const char
     CConstVarList             data(RHS);
 
     size_t                    fingerCount = 0;
-    eTrackpadGestureDirection direction   = TRACKPAD_GESTURE_DIR_NONE;
 
     try {
         fingerCount = std::stoul(std::string{data[0]});
@@ -276,12 +315,7 @@ static Hyprlang::CParseResult overviewGestureKeyword(const char* LHS, const char
         return result;
     }
 
-    if (fingerCount <= 1 || fingerCount >= 10) {
-        result.setError(std::format("Invalid value {} for finger count", data[0]).c_str());
-        return result;
-    }
-
-    direction = g_pTrackpadGestures->dirForString(data[1]);
+    const auto direction = g_pTrackpadGestures->dirForString(data[1]);
 
     if (direction == TRACKPAD_GESTURE_DIR_NONE) {
         result.setError(std::format("Invalid direction: {}", data[1]).c_str());
@@ -312,21 +346,10 @@ static Hyprlang::CParseResult overviewGestureKeyword(const char* LHS, const char
         break;
     }
 
-    std::expected<void, std::string> resultFromGesture;
+    const auto resultFromGesture = applyOverviewGesture(fingerCount, direction, std::string{data[startDataIdx]}, modMask, deltaScale);
 
-    if (data[startDataIdx] == "overview")
-        resultFromGesture = g_pTrackpadGestures->addGesture(makeUnique<COverviewGesture>(), fingerCount, direction, modMask, deltaScale, false);
-    else if (data[startDataIdx] == "unset")
-        resultFromGesture = g_pTrackpadGestures->removeGesture(fingerCount, direction, modMask, deltaScale, false);
-    else {
-        result.setError(std::format("Invalid gesture: {}", data[startDataIdx]).c_str());
-        return result;
-    }
-
-    if (!resultFromGesture) {
+    if (!resultFromGesture)
         result.setError(resultFromGesture.error().c_str());
-        return result;
-    }
 
     return result;
 }
@@ -385,7 +408,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 
     HyprlandAPI::addDispatcherV2(SCROLLOVERVIEW_HANDLE, "scrolloverview:overview", ::onOverviewDispatcher);
 
-    ScrollOverview::Config::registerLua(::onOverviewDispatcher);
+    ScrollOverview::Config::registerLua(::onOverviewDispatcher, ::onRegisterOverviewGesture);
 
     HyprlandAPI::addConfigKeyword(SCROLLOVERVIEW_HANDLE, "scrolloverview-gesture", ::overviewGestureKeyword, {});
 
@@ -403,5 +426,8 @@ APICALL EXPORT void PLUGIN_EXIT() {
     g_pScrollOverview.reset();
     disableScrollOverviewHooks();
 
-    HyprlandAPI::reloadConfig(); // we need to reload now to clear all the gestures
+    if (g_pTrackpadGestures)
+        g_pTrackpadGestures->clearGestures();
+
+    HyprlandAPI::reloadConfig(); // re-adds built-in gestures cleared above
 }

--- a/main.cpp
+++ b/main.cpp
@@ -261,7 +261,7 @@ static void* findFnOrThrow(const std::string& name, std::initializer_list<std::s
 // shared core: register / unregister the overview trackpad gesture. used by both the hyprlang
 // keyword and the Lua `scrolloverview.gesture` function so both configure the same gesture system.
 static std::expected<void, std::string> applyOverviewGesture(size_t fingerCount, eTrackpadGestureDirection direction, const std::string& action, uint32_t modMask,
-                                                             float deltaScale) {
+                                                             float deltaScale, bool disableInhibit) {
     if (fingerCount <= 1 || fingerCount >= 10)
         return std::unexpected(std::format("Invalid value {} for finger count", fingerCount));
 
@@ -269,17 +269,18 @@ static std::expected<void, std::string> applyOverviewGesture(size_t fingerCount,
         return std::unexpected("Invalid direction");
 
     if (action == "overview")
-        return g_pTrackpadGestures->addGesture(makeUnique<COverviewGesture>(), fingerCount, direction, modMask, deltaScale, false);
+        return g_pTrackpadGestures->addGesture(makeUnique<COverviewGesture>(), fingerCount, direction, modMask, deltaScale, disableInhibit);
 
     if (action == "unset")
-        return g_pTrackpadGestures->removeGesture(fingerCount, direction, modMask, deltaScale, false);
+        return g_pTrackpadGestures->removeGesture(fingerCount, direction, modMask, deltaScale, disableInhibit);
 
     return std::unexpected(std::format("Invalid gesture: {}", action));
 }
 
 // Lua-facing registrar (scrolloverview.gesture). takes the direction/mods as strings and resolves
 // them the same way the keyword does, then defers to applyOverviewGesture.
-static SDispatchResult onRegisterOverviewGesture(size_t fingerCount, const std::string& directionStr, const std::string& action, const std::string& mods, float deltaScale) {
+static SDispatchResult onRegisterOverviewGesture(size_t fingerCount, const std::string& directionStr, const std::string& action, const std::string& mods, float deltaScale,
+                                                 bool disableInhibit) {
     if (g_unloading)
         return {};
 
@@ -291,7 +292,7 @@ static SDispatchResult onRegisterOverviewGesture(size_t fingerCount, const std::
     if (!mods.empty() && g_pKeybindManager)
         modMask = g_pKeybindManager->stringToModMask(mods);
 
-    const auto res = applyOverviewGesture(fingerCount, direction, action, modMask, std::clamp(deltaScale, 0.1F, 10.F));
+    const auto res = applyOverviewGesture(fingerCount, direction, action, modMask, std::clamp(deltaScale, 0.1F, 10.F), disableInhibit);
     if (!res)
         return {.success = false, .error = res.error()};
 
@@ -322,9 +323,10 @@ static Hyprlang::CParseResult overviewGestureKeyword(const char* LHS, const char
         return result;
     }
 
-    int      startDataIdx = 2;
-    uint32_t modMask      = 0;
-    float    deltaScale   = 1.F;
+    int      startDataIdx   = 2;
+    uint32_t modMask        = 0;
+    float    deltaScale     = 1.F;
+    bool     disableInhibit = false;
 
     while (true) {
 
@@ -341,12 +343,16 @@ static Hyprlang::CParseResult overviewGestureKeyword(const char* LHS, const char
                 result.setError(std::format("Invalid delta scale: {}", std::string{data[startDataIdx].substr(6)}).c_str());
                 return result;
             }
+        } else if (data[startDataIdx] == "disable_inhibit") {
+            disableInhibit = true;
+            startDataIdx++;
+            continue;
         }
 
         break;
     }
 
-    const auto resultFromGesture = applyOverviewGesture(fingerCount, direction, std::string{data[startDataIdx]}, modMask, deltaScale);
+    const auto resultFromGesture = applyOverviewGesture(fingerCount, direction, std::string{data[startDataIdx]}, modMask, deltaScale, disableInhibit);
 
     if (!resultFromGesture)
         result.setError(resultFromGesture.error().c_str());

--- a/scrollOverview.cpp
+++ b/scrollOverview.cpp
@@ -1149,11 +1149,8 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
         // scroll across the workspace-stacking axis: drive the scrolling-layout tape 1:1, snapping to the nearest column on release
         if (ACTION != ScrollOverview::Config::EScrollAction::WORKSPACE) {
             const auto WORKSPACE = images[viewportCurrentWorkspace]->pWorkspace;
-            auto*      ALGO = (WORKSPACE && WORKSPACE->m_space && WORKSPACE->m_space->algorithm())
-                              ? dynamic_cast<Layout::Tiled::CScrollingAlgorithm*>(WORKSPACE->m_space->algorithm()->m_tiled.get())
-                              : nullptr;
+            const auto ALGO = overviewScrollingAlgorithmForWorkspace(WORKSPACE);
 
-            // non-scrolling workspace?
             if (!ALGO) {
                 return;
             }
@@ -1168,7 +1165,7 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
             }
 
             tapeFollowing = true;
-            ALGO->moveTape(sc<float>(-1 * e.delta / SCALE)); // /scale keeps the columns tracking the finger 1:1 in the scaled overview
+            ALGO->moveTape(sc<float>(-1 * e.delta / SCALE));
             damage();
             return;
         }
@@ -3790,6 +3787,10 @@ bool CScrollOverview::shouldHandleSurfaceDamage(SP<CWLSurfaceResource> surface) 
 }
 
 void CScrollOverview::close() {
+    if (closeApplied)
+        return;
+    closeApplied = true;
+
     setClosing(true);
 
     const auto SELECTEDWORKSPACE =
@@ -4116,7 +4117,7 @@ void CScrollOverview::onSwipeUpdate(double delta) {
 
     m_isSwiping = true;
 
-    const float PERC = closing ? std::clamp(delta / (double)DISTANCE, 0.0, 1.0) : 1.0 - std::clamp(delta / (double)DISTANCE, 0.0, 1.0);
+    const float PERC = closing ? 1.0 - std::clamp(delta / (double)DISTANCE, 0.0, 1.0) : std::clamp(delta / (double)DISTANCE, 0.0, 1.0);
 
     scale->setValueAndWarp(hyprlerp(1.F, ScrollOverview::Config::getScale(), PERC));
 }

--- a/scrollOverview.cpp
+++ b/scrollOverview.cpp
@@ -1030,8 +1030,90 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
         if (MODS != 0)
             return;
 
+        const bool HORIZONTAL       = e.axis == WL_POINTER_AXIS_HORIZONTAL_SCROLL;
+        const bool LAYOUTHORIZONTAL = layout == ScrollOverview::Config::ELayout::HORIZONTAL;
+        const bool WORKSPACEAXIS    = HORIZONTAL == LAYOUTHORIZONTAL; // scrolling along the workspace-stacking axis pages workspaces; the other axis drives the tape/selection
+
         info.cancelled = true;
-        moveViewportWorkspace(e.delta > 0);
+
+        // mouse wheel: discrete stepping, throttled by scroll_event_delay so one notch is one step
+        if (e.source == WL_POINTER_AXIS_SOURCE_WHEEL) {
+            if (e.delta == 0.0)
+                return;
+            scrollAccum        = 0.0;
+            workspaceFollowing = false;
+            tapeFollowing      = false;
+            if (!scrollStepAllowed(e.timeMs))
+                return;
+            if (WORKSPACEAXIS)
+                moveViewportWorkspace(e.delta > 0);
+            else
+                moveWindowSelection(e.delta > 0 ? "r" : "l");
+            return;
+        }
+
+        if (images.empty() || viewportCurrentWorkspace >= images.size())
+            return;
+
+        const auto MONITOR = pMonitor.lock();
+        if (!MONITOR)
+            return;
+
+        const float SCALE = std::max<float>(scale->value(), 0.01F);
+
+        // scroll across the workspace-stacking axis: drive the scrolling-layout tape 1:1, snapping to the nearest column on release
+        if (!WORKSPACEAXIS) {
+            const auto WORKSPACE = images[viewportCurrentWorkspace]->pWorkspace;
+            auto*      ALGO = (WORKSPACE && WORKSPACE->m_space && WORKSPACE->m_space->algorithm())
+                              ? dynamic_cast<Layout::Tiled::CScrollingAlgorithm*>(WORKSPACE->m_space->algorithm()->m_tiled.get())
+                              : nullptr;
+
+            // non-scrolling workspace: fall back to discrete focus stepping, throttled by scroll_event_delay
+            if (!ALGO) {
+                if (e.delta == 0.0 || !scrollStepAllowed(e.timeMs))
+                    return;
+                moveWindowSelection(e.delta > 0 ? "r" : "l");
+                return;
+            }
+
+            if (e.delta == 0.0) { // fingers lifted — snap the tape to the nearest column
+                if (tapeFollowing) {
+                    tapeFollowing = false;
+                    ALGO->snapToGrid();
+                    damage();
+                }
+                return;
+            }
+
+            tapeFollowing = true;
+            ALGO->moveTape(sc<float>(-1 * e.delta / SCALE)); // /scale keeps the columns tracking the finger 1:1 in the scaled overview
+            damage();
+            return;
+        }
+
+        // scroll along the workspace-stacking axis: 1:1 workspace follow, snapping to the nearest workspace on release
+        const float PITCH = getWorkspaceLogicalPitch(MONITOR, SCALE, layout); // logical px per workspace
+
+        if (e.delta == 0.0) { // fingers lifted — settle on the nearest workspace
+            finishWorkspaceScrollFollow(PITCH);
+            return;
+        }
+
+        workspaceFollowing = true;
+        scrollAccum += e.delta;
+
+        // finger travel (logical screen px) -> view offset (overview logical px); /SCALE keeps the content under the finger 1:1
+        double offset = scrollAccum / SCALE;
+
+        // clamp so the view can't be dragged past the first / last workspace
+        const double curIdx  = sc<double>(viewportCurrentWorkspace);
+        const double maxNext = (sc<double>(images.size()) - 1.0 - curIdx) * PITCH;
+        const double maxPrev = -curIdx * PITCH;
+        offset               = std::clamp(offset, maxPrev, maxNext);
+        scrollAccum          = offset * SCALE; // re-sync the accumulator to the clamped offset so it can't wind up past the ends
+
+        viewOffset->setValueAndWarp(axisOffsetVector(sc<float>(offset), layout)); // pan along the workspace-stacking axis
+        damage();
     };
 
     auto onWindowOpen = [this](PHLWINDOW) {
@@ -2082,6 +2164,49 @@ void CScrollOverview::moveViewportWorkspace(bool up) {
         pMonitor->changeWorkspace(TARGETWORKSPACEIMAGE->pWorkspace, false, true, true);
 
     damage();
+}
+
+bool CScrollOverview::scrollStepAllowed(uint32_t timeMs) {
+    const uint32_t DELAY = sc<uint32_t>(ScrollOverview::Config::getScrollEventDelay());
+
+    // throttle discrete scroll steps so a single notch / a burst of high-res events only steps once
+    if (lastScrollStepTimeMs != 0 && timeMs >= lastScrollStepTimeMs && timeMs - lastScrollStepTimeMs < DELAY)
+        return false;
+
+    lastScrollStepTimeMs = timeMs;
+    return true;
+}
+
+void CScrollOverview::finishWorkspaceScrollFollow(float logicalPitch) {
+    if (!workspaceFollowing)
+        return;
+
+    workspaceFollowing = false;
+    scrollAccum        = 0.0;
+
+    const double OFFSET = axisValue(viewOffset->value(), layout); // offset along the workspace-stacking axis
+    const long   STEPS  = std::lround(OFFSET / logicalPitch); // +next / -previous
+
+    if (STEPS == 0) {
+        *viewOffset = Vector2D{}; // didn't drag far enough — snap back to the current workspace
+        return;
+    }
+
+    // commit the workspace change, but have onWorkspaceChange settle from the current drag position
+    // (the leftover sub-pitch remainder) instead of warping a full pitch — keeps the slide seamless
+    gestureSettleOffset  = OFFSET - sc<double>(STEPS) * logicalPitch;
+    gestureSettlePending = true;
+
+    const size_t BEFORE = viewportCurrentWorkspace;
+    const bool   NEXT   = STEPS > 0;
+    for (long i = 0; i < std::abs(STEPS); ++i)
+        moveViewportWorkspace(NEXT);
+
+    if (viewportCurrentWorkspace == BEFORE) {
+        // nothing actually moved (already at an edge) — no workspace change will fire, so settle here
+        gestureSettlePending = false;
+        *viewOffset          = Vector2D{};
+    }
 }
 
 void CScrollOverview::syncSelectionToViewport() {
@@ -3434,6 +3559,12 @@ void CScrollOverview::onWorkspaceChange() {
 
     const auto previousActiveIdx = activeWorkspaceIndex();
     const auto previousStartedOn = startedOn;
+
+    // consume any pending gesture-driven settle (set by finishWorkspaceScrollFollow)
+    const bool   GESTURESETTLE       = gestureSettlePending;
+    const double GESTURESETTLEOFFSET = gestureSettleOffset;
+    gestureSettlePending             = false;
+
     std::vector<WORKSPACEID> previousWorkspaceIDs;
     previousWorkspaceIDs.reserve(images.size());
     std::unordered_map<WORKSPACEID, float> previousWorkspaceOffsets;
@@ -3502,7 +3633,10 @@ void CScrollOverview::onWorkspaceChange() {
         workspaceInsertTransition.transitionOldRelativeOffset = 0.F;
         workspaceInsertProgress->setValueAndWarp(1.F);
         workspaceInsertFadeProgress->setValueAndWarp(1.F);
-        viewOffset->setValueAndWarp(
+        if (GESTURESETTLE) // a trackpad follow committed this change: settle from the drag position, not a full pitch
+            viewOffset->setValueAndWarp(axisOffsetVector(sc<float>(GESTURESETTLEOFFSET), layout));
+        else
+            viewOffset->setValueAndWarp(
             axisOffsetVector(workspaceOverviewLogicalOffset(previousActiveIdx, viewportCurrentWorkspace, getWorkspaceLogicalPitch(pMonitor.lock(), scale->value(), layout)), layout));
         *viewOffset = Vector2D{};
     }

--- a/scrollOverview.cpp
+++ b/scrollOverview.cpp
@@ -1123,9 +1123,9 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
         if (e.source == WL_POINTER_AXIS_SOURCE_WHEEL) {
             if (e.delta == 0.0)
                 return;
-            scrollAccum        = 0.0;
-            workspaceFollowing = false;
-            tapeFollowing      = false;
+            trackpadScrollAccum        = 0.0;
+            trackpadWorkspaceFollowing = false;
+            trackpadTapeFollowing      = false;
             if (!scrollStepAllowed(e.timeMs))
                 return;
 
@@ -1140,59 +1140,11 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
         if (images.empty() || viewportCurrentWorkspace >= images.size())
             return;
 
-        const auto MONITOR = pMonitor.lock();
-        if (!MONITOR)
-            return;
-
-        const float SCALE = std::max<float>(scale->value(), 0.01F);
-
-        // scroll across the workspace-stacking axis: drive the scrolling-layout tape 1:1, snapping to the nearest column on release
-        if (ACTION != ScrollOverview::Config::EScrollAction::WORKSPACE) {
-            const auto WORKSPACE = images[viewportCurrentWorkspace]->pWorkspace;
-            const auto ALGO = overviewScrollingAlgorithmForWorkspace(WORKSPACE);
-
-            if (!ALGO) {
-                return;
-            }
-
-            if (e.delta == 0.0) { // fingers lifted — snap the tape to the nearest column
-                if (tapeFollowing) {
-                    tapeFollowing = false;
-                    ALGO->snapToGrid();
-                    damage();
-                }
-                return;
-            }
-
-            tapeFollowing = true;
-            ALGO->moveTape(sc<float>(-1 * e.delta / SCALE));
-            damage();
-            return;
-        }
-
-        // scroll along the workspace-stacking axis: 1:1 workspace follow, snapping to the nearest workspace on release
-        const float PITCH = getWorkspaceLogicalPitch(MONITOR, SCALE, layout); // logical px per workspace
-
-        if (e.delta == 0.0) { // fingers lifted — settle on the nearest workspace
-            finishWorkspaceScrollFollow(PITCH);
-            return;
-        }
-
-        workspaceFollowing = true;
-        scrollAccum += e.delta;
-
-        // finger travel (logical screen px) -> view offset (overview logical px); /SCALE keeps the content under the finger 1:1
-        double offset = scrollAccum / SCALE;
-
-        // clamp so the view can't be dragged past the first / last workspace
-        const double curIdx  = sc<double>(viewportCurrentWorkspace);
-        const double maxNext = (sc<double>(images.size()) - 1.0 - curIdx) * PITCH;
-        const double maxPrev = -curIdx * PITCH;
-        offset               = std::clamp(offset, maxPrev, maxNext);
-        scrollAccum          = offset * SCALE; // re-sync the accumulator to the clamped offset so it can't wind up past the ends
-
-        viewOffset->setValueAndWarp(axisOffsetVector(sc<float>(offset), layout)); // pan along the workspace-stacking axis
-        damage();
+        // scroll workspace or layout with 1:1 animation (snaping on release)
+        if (ACTION == ScrollOverview::Config::EScrollAction::WORKSPACE)
+            trackpadSwipeWorkspace(e.delta);
+        else
+            trackpadSwipeLayout(images[viewportCurrentWorkspace]->pWorkspace, e.delta);
     };
 
     auto onWindowOpen = [this](PHLWINDOW) {
@@ -2505,25 +2457,76 @@ bool CScrollOverview::scrollStepAllowed(uint32_t timeMs) {
     return true;
 }
 
-void CScrollOverview::finishWorkspaceScrollFollow(float logicalPitch) {
-    if (!workspaceFollowing)
-        return;
+void CScrollOverview::trackpadSwipeLayout(const PHLWORKSPACE target, const double delta) {
+    const float SCALE = std::max<float>(scale->value(), 0.01F);
+    const auto ALGO = overviewScrollingAlgorithmForWorkspace(target);
 
-    workspaceFollowing = false;
-    scrollAccum        = 0.0;
-
-    const double OFFSET = axisValue(viewOffset->value(), layout); // offset along the workspace-stacking axis
-    const long   STEPS  = std::lround(OFFSET / logicalPitch); // +next / -previous
-
-    if (STEPS == 0) {
-        *viewOffset = Vector2D{}; // didn't drag far enough — snap back to the current workspace
+    if (!ALGO) {
         return;
     }
 
-    // commit the workspace change, but have onWorkspaceChange settle from the current drag position
-    // (the leftover sub-pitch remainder) instead of warping a full pitch — keeps the slide seamless
-    gestureSettleOffset  = OFFSET - sc<double>(STEPS) * logicalPitch;
-    gestureSettlePending = true;
+    // fingers lifted — snap to the nearest column
+    if (delta == 0.0) {
+        if (trackpadTapeFollowing) {
+            trackpadTapeFollowing = false;
+            ALGO->snapToGrid();
+            damage();
+        }
+        return;
+    }
+
+    trackpadTapeFollowing = true;
+    ALGO->moveTape(sc<float>(-1 * delta / SCALE));
+    damage();
+}
+
+void CScrollOverview::trackpadSwipeWorkspace(const double delta) {
+    const auto MONITOR = pMonitor.lock();
+    if (!MONITOR)
+        return;
+
+    const float SCALE = std::max<float>(scale->value(), 0.01F);
+    const float PITCH = getWorkspaceLogicalPitch(MONITOR, SCALE, layout);
+
+    // fingers lifted — snap to the nearest workspace
+    if (delta == 0.0) {
+        finishWorkspaceScrollFollow(PITCH);
+        return;
+    }
+
+    trackpadWorkspaceFollowing  = true;
+    trackpadScrollAccum         += delta;
+
+    double offset = trackpadScrollAccum / SCALE;
+
+    // clamp so the view can't be dragged past the first / last workspace
+    const double curIdx  = sc<double>(viewportCurrentWorkspace);
+    const double maxNext = (sc<double>(images.size()) - 1.0 - curIdx) * PITCH;
+    const double maxPrev = -curIdx * PITCH;
+    offset               = std::clamp(offset, maxPrev, maxNext);
+    trackpadScrollAccum  = offset * SCALE;
+
+    viewOffset->setValueAndWarp(axisOffsetVector(sc<float>(offset), layout));
+    damage();
+}
+
+void CScrollOverview::finishWorkspaceScrollFollow(float logicalPitch) {
+    if (!trackpadWorkspaceFollowing)
+        return;
+
+    trackpadWorkspaceFollowing  = false;
+    trackpadScrollAccum         = 0.0;
+
+    const double OFFSET = axisValue(viewOffset->value(), layout);
+    const long   STEPS  = std::lround(OFFSET / logicalPitch);
+
+    if (STEPS == 0) {
+        *viewOffset = Vector2D{};
+        return;
+    }
+
+    trackpadGestureSettleOffset  = OFFSET - sc<double>(STEPS) * logicalPitch;
+    trackpadGestureSettlePending = true;
 
     const size_t BEFORE = viewportCurrentWorkspace;
     const bool   NEXT   = STEPS > 0;
@@ -2531,9 +2534,8 @@ void CScrollOverview::finishWorkspaceScrollFollow(float logicalPitch) {
         moveViewportWorkspace(NEXT);
 
     if (viewportCurrentWorkspace == BEFORE) {
-        // nothing actually moved (already at an edge) — no workspace change will fire, so settle here
-        gestureSettlePending = false;
-        *viewOffset          = Vector2D{};
+        trackpadGestureSettlePending = false;
+        *viewOffset                  = Vector2D{};
     }
 }
 
@@ -3898,9 +3900,9 @@ void CScrollOverview::onWorkspaceChange() {
     const auto previousStartedOn = startedOn;
 
     // consume any pending gesture-driven settle (set by finishWorkspaceScrollFollow)
-    const bool   GESTURESETTLE       = gestureSettlePending;
-    const double GESTURESETTLEOFFSET = gestureSettleOffset;
-    gestureSettlePending             = false;
+    const bool   GESTURESETTLE       = trackpadGestureSettlePending;
+    const double GESTURESETTLEOFFSET = trackpadGestureSettleOffset;
+    trackpadGestureSettlePending     = false;
 
     std::vector<WORKSPACEID> previousWorkspaceIDs;
     previousWorkspaceIDs.reserve(images.size());

--- a/scrollOverview.cpp
+++ b/scrollOverview.cpp
@@ -2470,6 +2470,7 @@ void CScrollOverview::trackpadSwipeLayout(const PHLWORKSPACE target, const doubl
         if (trackpadTapeFollowing) {
             trackpadTapeFollowing = false;
             ALGO->snapToGrid();
+            focusMostVisibleScrollingWindow(target);
             damage();
         }
         return;

--- a/scrollOverview.hpp
+++ b/scrollOverview.hpp
@@ -233,6 +233,7 @@ class CScrollOverview : public IOverview {
     wl_event_source*                 realtimePreviewTimer = nullptr;
 
     bool                             closing = false;
+    bool                             closeApplied = false; // close() has run its teardown; guards against double-invocation
 
     CHyprSignalListener             mouseMoveHook;
     CHyprSignalListener             mouseButtonHook;

--- a/scrollOverview.hpp
+++ b/scrollOverview.hpp
@@ -65,6 +65,8 @@ class CScrollOverview : public IOverview {
     void   renderDraggedWindow(PHLMONITOR monitor, size_t activeIdx, float workspacePitch, float renderScale, const Time::steady_tp& now);
     void   renderPinnedFloatingWindows(PHLMONITOR monitor, float overviewScale, const Time::steady_tp& now);
     void   moveViewportWorkspace(bool up);
+    void   finishWorkspaceScrollFollow(float logicalPitch);
+    bool   scrollStepAllowed(uint32_t timeMs);
     bool   moveWindowSelection(const std::string& direction);
     void   rememberSelection(PHLWINDOW window);
     void   syncSelectionToViewport();
@@ -233,6 +235,13 @@ class CScrollOverview : public IOverview {
     CHyprSignalListener             workspaceActiveHook;
 
     bool                             swipe = false;
+
+    double                           scrollAccum  = 0.0; // accumulates continuous (trackpad) scroll deltas (screen px) during a 1:1 workspace follow drag
+    uint32_t                         lastScrollStepTimeMs = 0;      // event time of the last discrete scroll step, for scroll_event_delay throttling
+    bool                             workspaceFollowing   = false; // a trackpad drag is panning between workspaces (between first delta and the lift/stop event)
+    bool                             tapeFollowing        = false; // a trackpad drag is driving the scrolling-layout tape
+    bool                             gestureSettlePending = false; // onWorkspaceChange should settle from gestureSettleOffset instead of a full-pitch warp
+    double                           gestureSettleOffset  = 0.0;   // viewOffset.y (logical px) to settle from when committing a gesture-driven workspace change
 
     friend class CScrollOverviewPassElement;
 };

--- a/scrollOverview.hpp
+++ b/scrollOverview.hpp
@@ -65,6 +65,8 @@ class CScrollOverview : public IOverview {
     void   renderDraggedWindow(PHLMONITOR monitor, size_t activeIdx, float workspacePitch, float renderScale, const Time::steady_tp& now);
     void   renderPinnedFloatingWindows(PHLMONITOR monitor, float overviewScale, const Time::steady_tp& now);
     void   moveViewportWorkspace(bool up);
+    void   trackpadSwipeLayout(const PHLWORKSPACE target, const double delta);
+    void   trackpadSwipeWorkspace(const double delta);
     void   finishWorkspaceScrollFollow(float logicalPitch);
     bool   scrollStepAllowed(uint32_t timeMs);
     bool   moveWindowSelection(const std::string& direction);
@@ -252,12 +254,13 @@ class CScrollOverview : public IOverview {
 
     bool                             swipe = false;
 
-    double                           scrollAccum  = 0.0; // accumulates continuous (trackpad) scroll deltas (screen px) during a 1:1 workspace follow drag
     uint32_t                         lastScrollStepTimeMs = 0;      // event time of the last discrete scroll step, for scroll_event_delay throttling
-    bool                             workspaceFollowing   = false; // a trackpad drag is panning between workspaces (between first delta and the lift/stop event)
-    bool                             tapeFollowing        = false; // a trackpad drag is driving the scrolling-layout tape
-    bool                             gestureSettlePending = false; // onWorkspaceChange should settle from gestureSettleOffset instead of a full-pitch warp
-    double                           gestureSettleOffset  = 0.0;   // viewOffset.y (logical px) to settle from when committing a gesture-driven workspace change
+
+    double                           trackpadScrollAccum          = 0.0;
+    bool                             trackpadWorkspaceFollowing   = false;
+    bool                             trackpadTapeFollowing        = false;
+    bool                             trackpadGestureSettlePending = false;
+    double                           trackpadGestureSettleOffset  = 0.0;
 
     friend class CScrollOverviewPassElement;
 };


### PR DESCRIPTION
Having used the Niri overview I miss how it handles gestures/scrolling using the trackpad on my laptop. In particular having 1:1 animations for opening the overview with a gesture and for scrolling workspaces / the layout with a two finger drag. I've tried to address this here.

### Changes.
- Add lua binding for the gesture (seems it was only available via hyprlang syntax and hadn't been updated for lua) and updated the README to include info on how to configure it.
- Added 1:1 scrolling animation (trackpad 2 finger scroll) for scrolling the layout and switching workspaces (snapping on release).
- Added a de bounce option for scroll events as I was consistently scrolling past multiple workspaces with a single scrollwheel notch when using a mouse. 
- Fixed a couple of issues where I was getting null pointer exceptions when using the gesture to close the overview (close() function getting called twice)