### PR TITLE
Keybind submap

### DIFF
--- a/Config.cpp
+++ b/Config.cpp
@@ -15,11 +15,21 @@ extern "C" {
 
 namespace {
 
-ScrollOverview::Config::TOverviewDispatcher g_overviewDispatcher = nullptr;
-ScrollOverview::Config::TGestureRegistrar   g_gestureRegistrar   = nullptr;
+ScrollOverview::Config::TDispatcher       g_overviewDispatcher = nullptr;
+ScrollOverview::Config::TDispatcher       g_navigateDispatcher = nullptr;
+ScrollOverview::Config::TDispatcher       g_windowDispatcher   = nullptr;
+ScrollOverview::Config::TGestureRegistrar g_gestureRegistrar   = nullptr;
 
 bool isOverviewArgValid(const std::string_view arg) {
     return arg == "toggle" || arg == "select" || arg == "on" || arg == "enable" || arg == "off" || arg == "disable";
+}
+
+bool isNavigateArgValid(const std::string_view arg) {
+    return arg == "left" || arg == "right" || arg == "up" || arg == "down";
+}
+
+bool isWindowArgValid(const std::string_view arg) {
+    return arg == "select" || arg == "close";
 }
 
 int dispatchOverviewLua(lua_State* L, const char* arg) {
@@ -29,6 +39,28 @@ int dispatchOverviewLua(lua_State* L, const char* arg) {
     const auto result = g_overviewDispatcher(arg);
     if (!result.success)
         return luaL_error(L, "overview: %s", result.error.c_str());
+
+    return 0;
+}
+
+int dispatchNavigateLua(lua_State* L, const char* arg) {
+    if (!g_navigateDispatcher)
+        return luaL_error(L, "navigate: dispatcher is not registered");
+
+    const auto result = g_navigateDispatcher(arg);
+    if (!result.success)
+        return luaL_error(L, "navigate: %s", result.error.c_str());
+
+    return 0;
+}
+
+int dispatchWindowLua(lua_State* L, const char* arg) {
+    if (!g_windowDispatcher)
+        return luaL_error(L, "window: dispatcher is not registered");
+
+    const auto result = g_windowDispatcher(arg);
+    if (!result.success)
+        return luaL_error(L, "window: %s", result.error.c_str());
 
     return 0;
 }
@@ -55,6 +87,30 @@ int overviewDispatchOffLua(lua_State* L) {
 
 int overviewDispatchDisableLua(lua_State* L) {
     return dispatchOverviewLua(L, "disable");
+}
+
+int navigateDispatchLeftLua(lua_State* L) {
+    return dispatchNavigateLua(L, "left");
+}
+
+int navigateDispatchRightLua(lua_State* L) {
+    return dispatchNavigateLua(L, "right");
+}
+
+int navigateDispatchUpLua(lua_State* L) {
+    return dispatchNavigateLua(L, "up");
+}
+
+int navigateDispatchDownLua(lua_State* L) {
+    return dispatchNavigateLua(L, "down");
+}
+
+int windowDispatchSelectLua(lua_State* L) {
+    return dispatchWindowLua(L, "select");
+}
+
+int windowDispatchCloseLua(lua_State* L) {
+    return dispatchWindowLua(L, "close");
 }
 
 int overviewLua(lua_State* L) {
@@ -98,6 +154,74 @@ int overviewLua(lua_State* L) {
         lua_pushcfunction(L, overviewDispatchDisableLua);
     else
         return luaL_error(L, "overview: invalid argument '%s'", arg);
+
+    return 1;
+}
+
+int navigateLua(lua_State* L) {
+    if (lua_gettop(L) < 1 || lua_isnoneornil(L, 1))
+        return luaL_error(L, "navigate: expected a string argument");
+
+    if (!lua_isstring(L, 1))
+        return luaL_error(L, "navigate: expected a string argument");
+
+    const char* arg = lua_tostring(L, 1);
+    if (!isNavigateArgValid(arg))
+        return luaL_error(L, "navigate: invalid argument '%s'", arg);
+
+    if (g_pKeybindManager && g_pKeybindManager->m_currentKeybind && g_pKeybindManager->m_currentKeybind->handler == "__lua") {
+        if (!g_navigateDispatcher)
+            return luaL_error(L, "navigate: dispatcher is not registered");
+
+        const auto result = g_navigateDispatcher(arg);
+        if (!result.success)
+            return luaL_error(L, "navigate: %s", result.error.c_str());
+
+        return 0;
+    }
+
+    if (std::string_view{arg} == "left")
+        lua_pushcfunction(L, navigateDispatchLeftLua);
+    else if (std::string_view{arg} == "right")
+        lua_pushcfunction(L, navigateDispatchRightLua);
+    else if (std::string_view{arg} == "up")
+        lua_pushcfunction(L, navigateDispatchUpLua);
+    else if (std::string_view{arg} == "down")
+        lua_pushcfunction(L, navigateDispatchDownLua);
+    else
+        return luaL_error(L, "navigate: invalid argument '%s'", arg);
+
+    return 1;
+}
+
+int windowLua(lua_State* L) {
+    if (lua_gettop(L) < 1 || lua_isnoneornil(L, 1))
+        return luaL_error(L, "window: expected a string argument");
+
+    if (!lua_isstring(L, 1))
+        return luaL_error(L, "window: expected a string argument");
+
+    const char* arg = lua_tostring(L, 1);
+    if (!isWindowArgValid(arg))
+        return luaL_error(L, "window: invalid argument '%s'", arg);
+
+    if (g_pKeybindManager && g_pKeybindManager->m_currentKeybind && g_pKeybindManager->m_currentKeybind->handler == "__lua") {
+        if (!g_windowDispatcher)
+            return luaL_error(L, "window: dispatcher is not registered");
+
+        const auto result = g_windowDispatcher(arg);
+        if (!result.success)
+            return luaL_error(L, "window: %s", result.error.c_str());
+
+        return 0;
+    }
+
+    if (std::string_view{arg} == "select")
+        lua_pushcfunction(L, windowDispatchSelectLua);
+    else if (std::string_view{arg} == "close")
+        lua_pushcfunction(L, windowDispatchCloseLua);
+    else
+        return luaL_error(L, "window: invalid argument '%s'", arg);
 
     return 1;
 }
@@ -182,22 +306,59 @@ int gestureLua(lua_State* L) {
     return 0;
 }
 
+struct SDispatcherLuaRegistration {
+    std::string_view                    name;
+    ScrollOverview::Config::TDispatcher* dispatcher;
+    lua_CFunction                       luaFunction;
+};
+
+SDispatcherLuaRegistration* findDispatcherLuaRegistration(const std::string_view name) {
+    static SDispatcherLuaRegistration registrations[] = {
+        {"overview", &g_overviewDispatcher, ::overviewLua},
+        {"navigate", &g_navigateDispatcher, ::navigateLua},
+        {"window",   &g_windowDispatcher,   ::windowLua},
+    };
+
+    const auto MATCH = std::ranges::find_if(registrations, [name](const auto& registration) { return registration.name == name; });
+    return MATCH == std::end(registrations) ? nullptr : &*MATCH;
+}
+
 }
 
 namespace ScrollOverview::Config {
 
-void registerLua(TOverviewDispatcher dispatcher, TGestureRegistrar gestureRegistrar) {
+void registerDispatcher(const std::string& name, TDispatcher dispatcher) {
+    HyprlandAPI::addDispatcherV2(SCROLLOVERVIEW_HANDLE, "scrolloverview:" + name, dispatcher);
+
     if (::Config::mgr()->type() != ::Config::CONFIG_LUA)
         return;
 
-    g_overviewDispatcher = dispatcher;
-    g_gestureRegistrar   = gestureRegistrar;
-    HyprlandAPI::addLuaFunction(SCROLLOVERVIEW_HANDLE, "scrolloverview", "overview", ::overviewLua);
-    HyprlandAPI::addLuaFunction(SCROLLOVERVIEW_HANDLE, "scrolloverview", "configure", ::configureLua);
+    const auto LUA_REGISTRATION = findDispatcherLuaRegistration(name);
+    if (!LUA_REGISTRATION)
+        return;
+
+    *LUA_REGISTRATION->dispatcher = dispatcher;
+    HyprlandAPI::addLuaFunction(SCROLLOVERVIEW_HANDLE, "scrolloverview", std::string{LUA_REGISTRATION->name}, LUA_REGISTRATION->luaFunction);
+}
+
+void registerGesture(TGestureRegistrar gestureRegistrar, TGestureKeyword gestureKeyword) {
+    HyprlandAPI::addConfigKeyword(SCROLLOVERVIEW_HANDLE, "scrolloverview-gesture", gestureKeyword, {});
+
+    if (::Config::mgr()->type() != ::Config::CONFIG_LUA)
+        return;
+
+    g_gestureRegistrar = gestureRegistrar;
     HyprlandAPI::addLuaFunction(SCROLLOVERVIEW_HANDLE, "scrolloverview", "gesture", ::gestureLua);
 }
 
-void registerLegacy() {
+static void registerLuaConfig() {
+    if (::Config::mgr()->type() != ::Config::CONFIG_LUA)
+        return;
+
+    HyprlandAPI::addLuaFunction(SCROLLOVERVIEW_HANDLE, "scrolloverview", "configure", ::configureLua);
+}
+
+static void registerLegacy() {
     using namespace ::Config::Values;
 
     HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE,
@@ -230,6 +391,12 @@ void registerLegacy() {
                                   makeShared<CIntValue>("plugin:scrolloverview:shadow:render_power", "workspace card shadow render power", -1));
     HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE,
                                   makeShared<CColorValue>("plugin:scrolloverview:shadow:color", "workspace card shadow color", -1));
+}
+
+void registerConfig() {
+    registerLuaConfig();
+    registerLegacy();
+    HyprlandAPI::reloadConfig();
 }
 
 int getGestureDistance() {

--- a/Config.cpp
+++ b/Config.cpp
@@ -282,8 +282,8 @@ static void registerLegacy() {
                                   makeShared<CIntValue>("plugin:scrolloverview:input:drag_mode", "overview mouse drag behavior", 0,
                                                         SIntValueOptions{.min = 0, .max = 1}));
     HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE,
-                                  makeShared<CIntValue>("plugin:scrolloverview:input:drag_threshold", "overview drag threshold", -1,
-                                                        SIntValueOptions{.min = -1}));
+                                  makeShared<CIntValue>("plugin:scrolloverview:input:drag_threshold", "overview drag threshold", 10,
+                                                        SIntValueOptions{.min = 0}));
     HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE,
                                   makeShared<CIntValue>("plugin:scrolloverview:wallpaper", "wallpaper mode", 0, SIntValueOptions{.min = 0, .max = 2}));
     HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE, makeShared<CBoolValue>("plugin:scrolloverview:blur", "blur the overview wallpaper", false));
@@ -333,11 +333,7 @@ int getDragMode() {
 }
 
 int getDragThreshold() {
-    const auto THRESHOLD = getValue<int>("plugin:scrolloverview:input:drag_threshold");
-    if (THRESHOLD >= 0)
-        return THRESHOLD;
-
-    return std::max<int>(0, getValue<int>("binds:drag_threshold"));
+    return std::max<int>(0, getValue<int>("plugin:scrolloverview:input:drag_threshold"));
 }
 
 static EScrollAction defaultVerticalScrollAction(ELayout layout) {

--- a/Config.cpp
+++ b/Config.cpp
@@ -381,6 +381,9 @@ static void registerLegacy() {
                                   makeShared<CIntValue>("plugin:scrolloverview:input:drag_mode", "overview mouse drag behavior", 0,
                                                         SIntValueOptions{.min = 0, .max = 1}));
     HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE,
+                                  makeShared<CIntValue>("plugin:scrolloverview:input:drag_threshold", "overview drag threshold", -1,
+                                                        SIntValueOptions{.min = -1}));
+    HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE,
                                   makeShared<CIntValue>("plugin:scrolloverview:wallpaper", "wallpaper mode", 0, SIntValueOptions{.min = 0, .max = 2}));
     HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE, makeShared<CBoolValue>("plugin:scrolloverview:blur", "blur the overview wallpaper", false));
     HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE,
@@ -426,6 +429,14 @@ bool getLeftHanded() {
 
 int getDragMode() {
     return std::clamp(getValue<int>("plugin:scrolloverview:input:drag_mode"), 0, 1);
+}
+
+int getDragThreshold() {
+    const auto THRESHOLD = getValue<int>("plugin:scrolloverview:input:drag_threshold");
+    if (THRESHOLD >= 0)
+        return THRESHOLD;
+
+    return std::max<int>(0, getValue<int>("binds:drag_threshold"));
 }
 
 static EScrollAction defaultVerticalScrollAction(ELayout layout) {

--- a/Config.cpp
+++ b/Config.cpp
@@ -8,6 +8,8 @@
 #include <hyprland/src/config/values/types/StringValue.hpp>
 #include <hyprland/src/managers/KeybindManager.hpp>
 
+#include <regex>
+
 extern "C" {
 #include <lauxlib.h>
 #include <lua.h>
@@ -15,213 +17,128 @@ extern "C" {
 
 namespace {
 
-ScrollOverview::Config::TDispatcher       g_overviewDispatcher = nullptr;
-ScrollOverview::Config::TDispatcher       g_navigateDispatcher = nullptr;
-ScrollOverview::Config::TDispatcher       g_windowDispatcher   = nullptr;
 ScrollOverview::Config::TGestureRegistrar g_gestureRegistrar   = nullptr;
 
-bool isOverviewArgValid(const std::string_view arg) {
-    return arg == "toggle" || arg == "select" || arg == "on" || arg == "enable" || arg == "off" || arg == "disable";
+int dispatcherLua(lua_State* L, std::string_view name);
+
+using TArgValidator = bool (*)(std::string_view);
+
+struct SDispatcherRegistration {
+    std::string_view                    name;
+    std::regex                          argPattern;
+    std::string_view                    defaultArg;
+    std::string_view                    typeArgError;
+    std::string_view                    invalidArgError;
+    TArgValidator                       argValidator = nullptr;
+    ScrollOverview::Config::TDispatcher dispatcher   = nullptr;
+    lua_CFunction                       luaFunction  = nullptr;
+
+    bool isArgValid(const std::string_view arg) const {
+        if (argValidator)
+            return argValidator(arg);
+
+        return std::regex_match(arg.begin(), arg.end(), argPattern);
+    }
+};
+
+SDispatcherRegistration* findDispatcherRegistration(const std::string_view name) {
+    static SDispatcherRegistration registrations[] = {
+        {
+            .name            = "overview",
+            .argPattern      = std::regex{"^(toggle|select|on|enable|off|disable)$"},
+            .defaultArg      = "toggle",
+            .typeArgError    = "expected an optional string argument; did you forget quotes around it?",
+            .invalidArgError = "expected one of: toggle, select, on, enable, off, disable",
+            .luaFunction     = [](lua_State* L) { return dispatcherLua(L, "overview"); },
+        },
+        {
+            .name            = "navigate",
+            .argPattern      = std::regex{"^(left|right|up|down)$"},
+            .typeArgError    = "expected a string argument",
+            .invalidArgError = "expected one of: left, right, up, down",
+            .luaFunction     = [](lua_State* L) { return dispatcherLua(L, "navigate"); },
+        },
+        {
+            .name            = "window",
+            .argPattern      = std::regex{"^(select|close)$"},
+            .typeArgError    = "expected a string argument",
+            .invalidArgError = "expected one of: select, close",
+            .luaFunction     = [](lua_State* L) { return dispatcherLua(L, "window"); },
+        },
+    };
+
+    const auto MATCH = std::ranges::find_if(registrations, [name](const auto& registration) { return registration.name == name; });
+    return MATCH == std::end(registrations) ? nullptr : &*MATCH;
 }
 
-bool isNavigateArgValid(const std::string_view arg) {
-    return arg == "left" || arg == "right" || arg == "up" || arg == "down";
-}
+int dispatchLua(lua_State* L, const SDispatcherRegistration& registration, const char* arg) {
+    if (!registration.dispatcher)
+        return luaL_error(L, "%s: dispatcher is not registered", registration.name.data());
 
-bool isWindowArgValid(const std::string_view arg) {
-    return arg == "select" || arg == "close";
-}
-
-int dispatchOverviewLua(lua_State* L, const char* arg) {
-    if (!g_overviewDispatcher)
-        return luaL_error(L, "overview: dispatcher is not registered");
-
-    const auto result = g_overviewDispatcher(arg);
+    const auto result = registration.dispatcher(arg);
     if (!result.success)
-        return luaL_error(L, "overview: %s", result.error.c_str());
+        return luaL_error(L, "%s: %s", registration.name.data(), result.error.c_str());
 
     return 0;
 }
 
-int dispatchNavigateLua(lua_State* L, const char* arg) {
-    if (!g_navigateDispatcher)
-        return luaL_error(L, "navigate: dispatcher is not registered");
+void pushDispatcherAction(lua_State* L, const char* name, const char* arg) {
+    const std::string CODE = "return function() return hl.plugin.scrolloverview._dispatch(\"" + std::string{name} + "\", \"" + std::string{arg} + "\") end";
 
-    const auto result = g_navigateDispatcher(arg);
-    if (!result.success)
-        return luaL_error(L, "navigate: %s", result.error.c_str());
+    if (luaL_loadstring(L, CODE.c_str()) != LUA_OK)
+        lua_error(L);
 
-    return 0;
+    if (lua_pcall(L, 0, 1, 0) != LUA_OK)
+        lua_error(L);
 }
 
-int dispatchWindowLua(lua_State* L, const char* arg) {
-    if (!g_windowDispatcher)
-        return luaL_error(L, "window: dispatcher is not registered");
+int dispatchInternalLua(lua_State* L) {
+    if (lua_gettop(L) < 2 || lua_isnoneornil(L, 1) || lua_isnoneornil(L, 2))
+        return luaL_error(L, "_dispatch: expected dispatcher name and argument");
 
-    const auto result = g_windowDispatcher(arg);
-    if (!result.success)
-        return luaL_error(L, "window: %s", result.error.c_str());
+    if (!lua_isstring(L, 1) || !lua_isstring(L, 2))
+        return luaL_error(L, "_dispatch: expected string arguments");
 
-    return 0;
+    const char* name = lua_tostring(L, 1);
+    const char* arg  = lua_tostring(L, 2);
+    const auto  REGISTRATION = findDispatcherRegistration(name);
+
+    if (!REGISTRATION)
+        return luaL_error(L, "_dispatch: unknown dispatcher '%s'", name);
+    if (!REGISTRATION->isArgValid(arg))
+        return luaL_error(L, "%s: invalid argument '%s', %s", name, arg, REGISTRATION->invalidArgError.data());
+
+    return dispatchLua(L, *REGISTRATION, arg);
 }
 
-int overviewDispatchToggleLua(lua_State* L) {
-    return dispatchOverviewLua(L, "toggle");
-}
+int dispatcherLua(lua_State* L, std::string_view name) {
+    const auto REGISTRATION = findDispatcherRegistration(name);
+    if (!REGISTRATION)
+        return luaL_error(L, "%s: dispatcher metadata is not registered", name.data());
 
-int overviewDispatchSelectLua(lua_State* L) {
-    return dispatchOverviewLua(L, "select");
-}
+    const char* arg = REGISTRATION->defaultArg.empty() ? nullptr : REGISTRATION->defaultArg.data();
 
-int overviewDispatchOnLua(lua_State* L) {
-    return dispatchOverviewLua(L, "on");
-}
-
-int overviewDispatchEnableLua(lua_State* L) {
-    return dispatchOverviewLua(L, "enable");
-}
-
-int overviewDispatchOffLua(lua_State* L) {
-    return dispatchOverviewLua(L, "off");
-}
-
-int overviewDispatchDisableLua(lua_State* L) {
-    return dispatchOverviewLua(L, "disable");
-}
-
-int navigateDispatchLeftLua(lua_State* L) {
-    return dispatchNavigateLua(L, "left");
-}
-
-int navigateDispatchRightLua(lua_State* L) {
-    return dispatchNavigateLua(L, "right");
-}
-
-int navigateDispatchUpLua(lua_State* L) {
-    return dispatchNavigateLua(L, "up");
-}
-
-int navigateDispatchDownLua(lua_State* L) {
-    return dispatchNavigateLua(L, "down");
-}
-
-int windowDispatchSelectLua(lua_State* L) {
-    return dispatchWindowLua(L, "select");
-}
-
-int windowDispatchCloseLua(lua_State* L) {
-    return dispatchWindowLua(L, "close");
-}
-
-int overviewLua(lua_State* L) {
-    const char* arg = "toggle";
+    if (!arg && (lua_gettop(L) < 1 || lua_isnoneornil(L, 1)))
+        return luaL_error(L, "%s: %s", REGISTRATION->name.data(), REGISTRATION->typeArgError.data());
 
     if (lua_gettop(L) >= 1) {
         if (lua_isnoneornil(L, 1))
-            return luaL_error(L, "overview: expected a string argument; did you forget quotes around it?");
+            return luaL_error(L, "%s: %s", REGISTRATION->name.data(), REGISTRATION->typeArgError.data());
 
         if (!lua_isstring(L, 1))
-            return luaL_error(L, "overview: expected an optional string argument");
+            return luaL_error(L, "%s: %s", REGISTRATION->name.data(), REGISTRATION->typeArgError.data());
 
         arg = lua_tostring(L, 1);
     }
 
-    if (!isOverviewArgValid(arg))
-        return luaL_error(L, "overview: invalid argument '%s'", arg);
+    if (!REGISTRATION->isArgValid(arg))
+        return luaL_error(L, "%s: invalid argument '%s', %s", REGISTRATION->name.data(), arg, REGISTRATION->invalidArgError.data());
 
     if (g_pKeybindManager && g_pKeybindManager->m_currentKeybind && g_pKeybindManager->m_currentKeybind->handler == "__lua") {
-        if (!g_overviewDispatcher)
-            return luaL_error(L, "overview: dispatcher is not registered");
-
-        const auto result = g_overviewDispatcher(arg);
-        if (!result.success)
-            return luaL_error(L, "overview: %s", result.error.c_str());
-
-        return 0;
+        return dispatchLua(L, *REGISTRATION, arg);
     }
 
-    if (std::string_view{arg} == "toggle")
-        lua_pushcfunction(L, overviewDispatchToggleLua);
-    else if (std::string_view{arg} == "select")
-        lua_pushcfunction(L, overviewDispatchSelectLua);
-    else if (std::string_view{arg} == "on")
-        lua_pushcfunction(L, overviewDispatchOnLua);
-    else if (std::string_view{arg} == "enable")
-        lua_pushcfunction(L, overviewDispatchEnableLua);
-    else if (std::string_view{arg} == "off")
-        lua_pushcfunction(L, overviewDispatchOffLua);
-    else if (std::string_view{arg} == "disable")
-        lua_pushcfunction(L, overviewDispatchDisableLua);
-    else
-        return luaL_error(L, "overview: invalid argument '%s'", arg);
-
-    return 1;
-}
-
-int navigateLua(lua_State* L) {
-    if (lua_gettop(L) < 1 || lua_isnoneornil(L, 1))
-        return luaL_error(L, "navigate: expected a string argument");
-
-    if (!lua_isstring(L, 1))
-        return luaL_error(L, "navigate: expected a string argument");
-
-    const char* arg = lua_tostring(L, 1);
-    if (!isNavigateArgValid(arg))
-        return luaL_error(L, "navigate: invalid argument '%s'", arg);
-
-    if (g_pKeybindManager && g_pKeybindManager->m_currentKeybind && g_pKeybindManager->m_currentKeybind->handler == "__lua") {
-        if (!g_navigateDispatcher)
-            return luaL_error(L, "navigate: dispatcher is not registered");
-
-        const auto result = g_navigateDispatcher(arg);
-        if (!result.success)
-            return luaL_error(L, "navigate: %s", result.error.c_str());
-
-        return 0;
-    }
-
-    if (std::string_view{arg} == "left")
-        lua_pushcfunction(L, navigateDispatchLeftLua);
-    else if (std::string_view{arg} == "right")
-        lua_pushcfunction(L, navigateDispatchRightLua);
-    else if (std::string_view{arg} == "up")
-        lua_pushcfunction(L, navigateDispatchUpLua);
-    else if (std::string_view{arg} == "down")
-        lua_pushcfunction(L, navigateDispatchDownLua);
-    else
-        return luaL_error(L, "navigate: invalid argument '%s'", arg);
-
-    return 1;
-}
-
-int windowLua(lua_State* L) {
-    if (lua_gettop(L) < 1 || lua_isnoneornil(L, 1))
-        return luaL_error(L, "window: expected a string argument");
-
-    if (!lua_isstring(L, 1))
-        return luaL_error(L, "window: expected a string argument");
-
-    const char* arg = lua_tostring(L, 1);
-    if (!isWindowArgValid(arg))
-        return luaL_error(L, "window: invalid argument '%s'", arg);
-
-    if (g_pKeybindManager && g_pKeybindManager->m_currentKeybind && g_pKeybindManager->m_currentKeybind->handler == "__lua") {
-        if (!g_windowDispatcher)
-            return luaL_error(L, "window: dispatcher is not registered");
-
-        const auto result = g_windowDispatcher(arg);
-        if (!result.success)
-            return luaL_error(L, "window: %s", result.error.c_str());
-
-        return 0;
-    }
-
-    if (std::string_view{arg} == "select")
-        lua_pushcfunction(L, windowDispatchSelectLua);
-    else if (std::string_view{arg} == "close")
-        lua_pushcfunction(L, windowDispatchCloseLua);
-    else
-        return luaL_error(L, "window: invalid argument '%s'", arg);
+    pushDispatcherAction(L, REGISTRATION->name.data(), arg);
 
     return 1;
 }
@@ -306,23 +223,6 @@ int gestureLua(lua_State* L) {
     return 0;
 }
 
-struct SDispatcherLuaRegistration {
-    std::string_view                    name;
-    ScrollOverview::Config::TDispatcher* dispatcher;
-    lua_CFunction                       luaFunction;
-};
-
-SDispatcherLuaRegistration* findDispatcherLuaRegistration(const std::string_view name) {
-    static SDispatcherLuaRegistration registrations[] = {
-        {"overview", &g_overviewDispatcher, ::overviewLua},
-        {"navigate", &g_navigateDispatcher, ::navigateLua},
-        {"window",   &g_windowDispatcher,   ::windowLua},
-    };
-
-    const auto MATCH = std::ranges::find_if(registrations, [name](const auto& registration) { return registration.name == name; });
-    return MATCH == std::end(registrations) ? nullptr : &*MATCH;
-}
-
 }
 
 namespace ScrollOverview::Config {
@@ -333,12 +233,12 @@ void registerDispatcher(const std::string& name, TDispatcher dispatcher) {
     if (::Config::mgr()->type() != ::Config::CONFIG_LUA)
         return;
 
-    const auto LUA_REGISTRATION = findDispatcherLuaRegistration(name);
-    if (!LUA_REGISTRATION)
+    const auto REGISTRATION = findDispatcherRegistration(name);
+    if (!REGISTRATION)
         return;
 
-    *LUA_REGISTRATION->dispatcher = dispatcher;
-    HyprlandAPI::addLuaFunction(SCROLLOVERVIEW_HANDLE, "scrolloverview", std::string{LUA_REGISTRATION->name}, LUA_REGISTRATION->luaFunction);
+    REGISTRATION->dispatcher = dispatcher;
+    HyprlandAPI::addLuaFunction(SCROLLOVERVIEW_HANDLE, "scrolloverview", std::string{REGISTRATION->name}, REGISTRATION->luaFunction);
 }
 
 void registerGesture(TGestureRegistrar gestureRegistrar, TGestureKeyword gestureKeyword) {
@@ -355,6 +255,7 @@ static void registerLuaConfig() {
     if (::Config::mgr()->type() != ::Config::CONFIG_LUA)
         return;
 
+    HyprlandAPI::addLuaFunction(SCROLLOVERVIEW_HANDLE, "scrolloverview", "_dispatch", ::dispatchInternalLua);
     HyprlandAPI::addLuaFunction(SCROLLOVERVIEW_HANDLE, "scrolloverview", "configure", ::configureLua);
 }
 

--- a/Config.hpp
+++ b/Config.hpp
@@ -12,7 +12,8 @@
 
 namespace ScrollOverview::Config {
 
-using TOverviewDispatcher = SDispatchResult (*)(std::string);
+using TDispatcher       = SDispatchResult (*)(std::string);
+using TGestureKeyword   = Hyprlang::CParseResult (*)(const char* LHS, const char* RHS);
 using TGestureRegistrar   = SDispatchResult (*)(size_t fingerCount, const std::string& direction, const std::string& action, const std::string& mods, float deltaScale,
                                                 bool disableInhibit);
 
@@ -26,8 +27,9 @@ enum class EScrollAction {
     COLUMN,
 };
 
-void registerLua(TOverviewDispatcher dispatcher, TGestureRegistrar gestureRegistrar);
-void registerLegacy();
+void registerDispatcher(const std::string& name, TDispatcher dispatcher);
+void registerGesture(TGestureRegistrar gestureRegistrar, TGestureKeyword gestureKeyword);
+void registerConfig();
 
 template <typename T>
 CConfigValue<T>& valueRef(const std::string& name) {

--- a/Config.hpp
+++ b/Config.hpp
@@ -79,17 +79,18 @@ int           getGestureDistance();
 float         getScale();
 int           getWorkspaceGap();
 ELayout       getLayout();
-int          getScrollEventDelay();
+int           getScrollEventDelay();
 bool          getLeftHanded();
 int           getDragMode();
+int           getDragThreshold();
 EScrollAction getVerticalScrollAction(ELayout layout);
 EScrollAction getHorizontalScrollAction(ELayout layout);
 int           getWallpaperMode();
 bool          getBlur();
 ::Config::CCssGapData getCssGapData(const std::string& name);
-int          getShadowEnabled();
-int          getShadowRange();
-int          getShadowRenderPower();
-int64_t      getShadowColor();
+int           getShadowEnabled();
+int           getShadowRange();
+int           getShadowRenderPower();
+int64_t       getShadowColor();
 
 }

--- a/IOverview.hpp
+++ b/IOverview.hpp
@@ -2,6 +2,8 @@
 #include <hyprland/src/helpers/memory/Memory.hpp>
 #include <hyprland/src/helpers/time/Time.hpp>
 
+#include <string>
+
 class CWLSurfaceResource;
 
 class IOverview {
@@ -26,6 +28,8 @@ class IOverview {
 
     virtual void  close()                  = 0;
     virtual void  selectHoveredWorkspace() = 0;
+    virtual bool  moveSelection(const std::string& direction) = 0;
+    virtual bool  windowDispatcherAction(const std::string& action) = 0;
 
     virtual void  fullRender() = 0;
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,54 @@ end)
 accepted by `hl.dispatch()` and binds. When called from inside a Lua keybind
 callback, it dispatches immediately.
 
+#### Submap
+
+Defining a `scrolloverview` submap replaces the built-in keyboard navigation in
+the overview. While the submap is active, normal Hyprland keybinds outside that
+submap are not handled unless they use Hyprland's `submap_universal` flag. This method allows greater configuration of the keybinds, for example it is possible to close the window under the mouse cursor with a click.
+
+```ini
+# hyprland.conf
+submap = scrolloverview
+    bind = , left,   scrolloverview:navigate, left
+    bind = , right,  scrolloverview:navigate, right
+    bind = , up,     scrolloverview:navigate, up
+    bind = , down,   scrolloverview:navigate, down
+    bind = , return, scrolloverview:overview, select
+    bind = , escape, scrolloverview:overview, off
+    bind = , mouse:272, scrolloverview:window, select # selects only; see Lua example below to also close
+    bind = , mouse:274, scrolloverview:window, close
+submap = reset
+
+# Example Hyprland bind that keeps working inside the submap:
+bind = ALT, 1, workspace, 1, submap_universal
+bind = ALT, 2, workspace, 2, submap_universal
+bind = ALT, 3, workspace, 3, submap_universal
+```
+
+```lua
+-- hyprland.lua
+hl.define_submap("scrolloverview", function()
+    hl.bind("left",   hl.plugin.scrolloverview.navigate("left"))
+    hl.bind("right",  hl.plugin.scrolloverview.navigate("right"))
+    hl.bind("up",     hl.plugin.scrolloverview.navigate("up"))
+    hl.bind("down",   hl.plugin.scrolloverview.navigate("down"))
+    hl.bind("return", hl.plugin.scrolloverview.overview("select"))
+    hl.bind("escape", hl.plugin.scrolloverview.overview("off"))
+    hl.bind("mouse:272", function()
+        hl.plugin.scrolloverview.window("select")
+        hl.plugin.scrolloverview.overview("off")
+    end, { mouse = true })
+    hl.bind("mouse:274", hl.plugin.scrolloverview.window("close"), { mouse = true })
+end)
+
+-- Example Hyprland bind that keeps working inside the submap:
+for i = 1, 10 do
+    local key = i % 10
+    hl.bind("ALT + " .. key, hl.dsp.focus({ workspace = i }), { submap_universal = true })
+end
+```
+
 ### Gesture
 
 The overview can be opened/closed with a trackpad swipe gesture. Configure it as follows.
@@ -186,15 +234,46 @@ hl.bind(mainMod .. " + Tab", function()
 end)
 ```
 
-Here are a list of options you can use:  
+### Dispatchers
+
+Dispatchers can be used from Hyprland binds as `scrolloverview:<dispatcher>` or
+from Lua as `hl.plugin.scrolloverview.<dispatcher>(...)`.
+
+#### `scrolloverview:overview`
+
+Controls the overview visibility.
+
 | option | description |
 | --- | --- |
-toggle | displays if hidden, hide if displayed
-select | selects the hovered desktop
-off | hides the overview
-disable | same as `off`
-on | displays the overview
-enable | same as `on`
+| `toggle` | show the overview if hidden, hide it if visible |
+| `select` | accept the currently selected workspace and close the overview |
+| `off` | hide the overview |
+| `disable` | same as `off` |
+| `on` | show the overview |
+| `enable` | same as `on` |
+
+#### `scrolloverview:navigate`
+
+Moves the overview selection/focus between windows in the current workspace. If
+there are no more windows in that direction, it selects the next workspace when
+the direction matches the configured overview layout.
+
+| option | description |
+| --- | --- |
+| `left` | move selection left |
+| `right` | move selection right |
+| `up` | move selection up |
+| `down` | move selection down |
+
+#### `scrolloverview:window`
+
+Acts on an overview window. Mouse binds use the window under the cursor;
+keyboard binds use the currently selected window.
+
+| option | description |
+| --- | --- |
+| `select` | focus/select the window under the mouse cursor |
+| `close` | close the window under the mouse cursor |
 
 ### Supported plugins
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ submap = scrolloverview
     bind = , down,   scrolloverview:navigate, down
     bind = , return, scrolloverview:overview, select
     bind = , escape, scrolloverview:overview, off
-    bind = , mouse:272, scrolloverview:window, select # selects only; see Lua example below to also close
+    bind = , mouse:272, scrolloverview:overview, select # selects the workspace under the cursor, multiple actions are not possible with Hyprlang
     bind = , mouse:274, scrolloverview:window, close
 submap = reset
 
@@ -170,6 +170,8 @@ hl.define_submap("scrolloverview", function()
     hl.bind("return", hl.plugin.scrolloverview.overview("select"))
     hl.bind("escape", hl.plugin.scrolloverview.overview("off"))
     hl.bind("mouse:272", function()
+        -- Select the clicked window, or just the workspace if no window was clicked, then close the overview. This is the default behaviour if submap is not defined.
+        hl.plugin.scrolloverview.overview("select")
         hl.plugin.scrolloverview.window("select")
         hl.plugin.scrolloverview.overview("off")
     end, { mouse = true })
@@ -242,12 +244,12 @@ from Lua as `hl.plugin.scrolloverview.<dispatcher>(...)`.
 
 #### `scrolloverview:overview`
 
-Controls the overview visibility.
+Controls the overview.
 
 | option | description |
 | --- | --- |
 | `toggle` | show the overview if hidden, hide it if visible |
-| `select` | accept the currently selected workspace and close the overview |
+| `select` | select the workspace under the cursor |
 | `off` | hide the overview |
 | `disable` | same as `off` |
 | `on` | show the overview |

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ In Lua, `shadow.color` must be an integer color value. The Hyprlang-only
 | scroll_event_delay | number | in ms, delay between scroll events (to prevent multiple activation) | `200` |
 | scrolling_mode | int | mouse wheel behavior: `0` layout-aware default, `1` inverted, `2` vertical scroll changes workspace and horizontal scroll changes columns, `3` vertical scroll changes columns and horizontal scroll changes workspace | `0` |
 | drag_mode | int | mouse drag behavior: `0` main button drags windows and middle button pans scrolling workspaces, `1` main button pans scrolling workspaces and middle button drags windows | `0` |
+| drag_threshold | int | movement threshold in pixels before a mouse press becomes drag/pan/resize instead of click; `0` disables the threshold | `binds:drag_threshold` |
 
 #### Subcategory `shadow`
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ In Lua, `shadow.color` must be an integer color value. The Hyprlang-only
 | scroll_event_delay | number | in ms, delay between scroll events (to prevent multiple activation) | `200` |
 | scrolling_mode | int | mouse wheel behavior: `0` layout-aware default, `1` inverted, `2` vertical scroll changes workspace and horizontal scroll changes columns, `3` vertical scroll changes columns and horizontal scroll changes workspace | `0` |
 | drag_mode | int | mouse drag behavior: `0` main button drags windows and middle button pans scrolling workspaces, `1` main button pans scrolling workspaces and middle button drags windows | `0` |
-| drag_threshold | int | movement threshold in pixels before a mouse press becomes drag/pan/resize instead of click; `0` disables the threshold | `binds:drag_threshold` |
+| drag_threshold | int | movement threshold in pixels before a mouse press becomes drag/pan/resize instead of click; `0` disables the threshold | `10` |
 
 #### Subcategory `shadow`
 

--- a/main.cpp
+++ b/main.cpp
@@ -65,7 +65,7 @@ bool ensureScrollOverviewHooks() {
 
     if (!success) {
         disableScrollOverviewHooks();
-        failNotif("Failed enabling overview hooks");
+        failNotif("Failed enabling overview hooks (is other overview plugin enabled?)");
         return false;
     }
 
@@ -181,10 +181,8 @@ static SDispatchResult onOverviewDispatcher(std::string arg) {
         return {.success = false, .error = "already swiping"};
 
     if (arg == "select") {
-        if (g_pScrollOverview) {
-            g_pScrollOverview->selectHoveredWorkspace();
+        if (g_pScrollOverview)
             g_pScrollOverview->close();
-        }
         return {};
     }
     if (arg == "toggle") {
@@ -192,7 +190,7 @@ static SDispatchResult onOverviewDispatcher(std::string arg) {
             g_pScrollOverview->close();
         else {
             if (!ensureScrollOverviewHooks())
-                return {.success = false, .error = "failed enabling overview hooks"};
+                return {.success = false, .error = "failed enabling overview hooks (is other overview plugin enabled?)"};
 
             renderingOverview = true;
             g_pScrollOverview = makeShared<CScrollOverview>(Desktop::focusState()->monitor()->m_activeWorkspace);
@@ -211,11 +209,33 @@ static SDispatchResult onOverviewDispatcher(std::string arg) {
         return {};
 
     if (!ensureScrollOverviewHooks())
-        return {.success = false, .error = "failed enabling overview hooks"};
+        return {.success = false, .error = "failed enabling overview hooks (is other overview plugin enabled?)"};
 
     renderingOverview = true;
     g_pScrollOverview = makeShared<CScrollOverview>(Desktop::focusState()->monitor()->m_activeWorkspace);
     renderingOverview = false;
+    return {};
+}
+
+static SDispatchResult onNavigateDispatcher(std::string arg) {
+    if (!g_pScrollOverview)
+        return {};
+
+    if (arg != "left" && arg != "right" && arg != "up" && arg != "down")
+        return {.success = false, .error = "invalid arg. expected left|right|up|down"};
+
+    g_pScrollOverview->moveSelection(arg);
+    return {};
+}
+
+static SDispatchResult onWindowDispatcher(std::string arg) {
+    if (!g_pScrollOverview)
+        return {};
+
+    if (arg != "select" && arg != "close")
+        return {.success = false, .error = "invalid arg. expected select|close"};
+
+    g_pScrollOverview->windowDispatcherAction(arg);
     return {};
 }
 
@@ -412,15 +432,11 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
         g_pScrollOverview->onPreRender();
     });
 
-    HyprlandAPI::addDispatcherV2(SCROLLOVERVIEW_HANDLE, "scrolloverview:overview", ::onOverviewDispatcher);
-
-    ScrollOverview::Config::registerLua(::onOverviewDispatcher, ::onRegisterOverviewGesture);
-
-    HyprlandAPI::addConfigKeyword(SCROLLOVERVIEW_HANDLE, "scrolloverview-gesture", ::overviewGestureKeyword, {});
-
-    ScrollOverview::Config::registerLegacy();
-
-    HyprlandAPI::reloadConfig();
+    ScrollOverview::Config::registerDispatcher("overview", ::onOverviewDispatcher);
+    ScrollOverview::Config::registerDispatcher("navigate", ::onNavigateDispatcher);
+    ScrollOverview::Config::registerDispatcher("window", ::onWindowDispatcher);
+    ScrollOverview::Config::registerGesture(::onRegisterOverviewGesture, ::overviewGestureKeyword);
+    ScrollOverview::Config::registerConfig();
 
     return {"scrolloverview", "A plugin for an overview", "Vaxry, yayuuu", "1.0"};
 }

--- a/main.cpp
+++ b/main.cpp
@@ -182,7 +182,7 @@ static SDispatchResult onOverviewDispatcher(std::string arg) {
 
     if (arg == "select") {
         if (g_pScrollOverview)
-            g_pScrollOverview->close();
+            g_pScrollOverview->selectHoveredWorkspace();
         return {};
     }
     if (arg == "toggle") {

--- a/scrollOverview.cpp
+++ b/scrollOverview.cpp
@@ -14,6 +14,7 @@
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/config/ConfigValue.hpp>
 #include <hyprland/src/config/ConfigManager.hpp>
+#include <hyprland/src/config/shared/actions/ConfigActions.hpp>
 #include <hyprland/src/config/shared/animation/AnimationTree.hpp>
 #include <hyprland/src/config/shared/complex/ComplexDataTypes.hpp>
 #include <hyprland/src/event/EventBus.hpp>
@@ -64,6 +65,7 @@ static void damageMonitor(WP<Hyprutils::Animation::CBaseAnimatedVariable> thispt
 }
 
 static PHLWINDOW getOverviewFullscreenVisibilityWindow(const PHLWORKSPACE& workspace, const PHLWINDOW& fallback = {});
+static constexpr const char* OVERVIEW_SUBMAP = "scrolloverview";
 
 static void removeOverview(WP<Hyprutils::Animation::CBaseAnimatedVariable> thisptr) {
     const auto PMONITOR = g_pScrollOverview ? g_pScrollOverview->pMonitor.lock() : nullptr;
@@ -88,6 +90,33 @@ static xkb_keysym_t getOverviewKeysym(const IKeyboard::SKeyEvent& event) {
         return XKB_KEY_NoSymbol;
 
     return xkb_state_key_get_one_sym(STATE, event.keycode + 8);
+}
+
+static bool hasOverviewSubmap() {
+    return g_pKeybindManager && std::ranges::any_of(g_pKeybindManager->m_keybinds, [](const auto& keybind) { return keybind && keybind->submap.name == OVERVIEW_SUBMAP; });
+}
+
+static SP<SKeybind> findOverviewSubmapMouseClick(uint32_t button) {
+    if (!g_pKeybindManager || !g_pInputManager)
+        return {};
+
+    const auto KEYNAME = "mouse:" + std::to_string(button);
+    const auto MODS    = g_pInputManager->getModsFromAllKBs();
+
+    for (const auto& keybind : g_pKeybindManager->m_keybinds) {
+        if (!keybind || !keybind->enabled || keybind->shadowed || keybind->key != KEYNAME)
+            continue;
+
+        if (keybind->submap.name != OVERVIEW_SUBMAP)
+            continue;
+
+        if (keybind->modmask != MODS && !keybind->ignoreMods)
+            continue;
+
+        return keybind;
+    }
+
+    return {};
 }
 
 static bool isTopLayerFocused(PHLMONITOR monitor) {
@@ -818,6 +847,7 @@ static void moveOverviewTargetNextToWindow(const SP<Layout::ITarget>& target, co
 }
 
 CScrollOverview::~CScrollOverview() {
+    restoreSubmapIfActive();
     if (const auto OPENGL = g_pHyprRenderer ? g_pHyprRenderer->glBackend().lock() : WP<Render::GL::CHyprOpenGLImpl>{})
         OPENGL->makeEGLCurrent();
     if (realtimePreviewTimer) {
@@ -845,6 +875,7 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
     const auto          PMONITOR = Desktop::focusState()->monitor();
     pMonitor                     = PMONITOR;
     layout                       = ScrollOverview::Config::getLayout();
+    usesSubmapKeybinds           = hasOverviewSubmap();
 
     applyWorkspaceAnimationOverrides();
     forceWorkspaceAlphaVisible();
@@ -900,11 +931,46 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
 
         lastMousePosLocal = getOverviewMousePosLocal(pMonitor.lock());
 
-        if (!dragPendingPrimary && !resizePointerDown && !scrollingPanPointerDown && !dragActiveWindow && !resizeActiveWindow && isPointerOnTopLayer(pMonitor.lock()))
+        if (!dragPendingPrimary && !resizePointerDown && !scrollingPanPointerDown && !dragActiveWindow && !resizeActiveWindow && isPointerOnTopLayer(pMonitor.lock())) {
+            submapMouseClickPending = false;
+            submapMouseClickButton  = 0;
+            submapMouseClickKeybind.reset();
             return;
+        }
 
         info.cancelled = true;
         requestInputFrame();
+
+        if (submapMouseClickPending) {
+            const bool     LEFT_HANDED          = ScrollOverview::Config::getLeftHanded();
+            const uint32_t MAIN_BUTTON          = LEFT_HANDED ? BTN_RIGHT : BTN_LEFT;
+            const bool     INVERT_DRAG_MODE     = ScrollOverview::Config::getDragMode() == 1;
+            const uint32_t SECONDARY_DRAG_BUTTON = BTN_MIDDLE;
+            const float    DRAGTHRESHOLD        = ScrollOverview::Config::getValue<int>("binds:drag_threshold") * (pMonitor ? pMonitor->m_scale : 1.F);
+            const bool     DRAGTHRESHOLDREACHED = dragStartMouseLocal.distanceSq(lastMousePosLocal) > std::pow(DRAGTHRESHOLD, 2);
+
+            if (submapMouseClickButton == MAIN_BUTTON && !dragActiveWindow && !scrollingPanPointerDown && DRAGTHRESHOLDREACHED) {
+                submapMouseClickPending = false;
+                submapMouseClickButton  = 0;
+                submapMouseClickKeybind.reset();
+
+                if (ScrollOverview::Config::getDragMode() == 0)
+                    beginWindowDrag(windowAtOverviewPoint(dragStartMouseLocal));
+                else if (const auto WORKSPACE = workspaceAtOverviewPoint(dragStartMouseLocal); isWorkspaceScrolling(WORKSPACE)) {
+                    beginScrollingPan(WORKSPACE);
+                    scrollingPanLastMouseLocal = dragStartMouseLocal;
+                    updateScrollingPan();
+                }
+            }
+
+            if (submapMouseClickButton == SECONDARY_DRAG_BUTTON && !INVERT_DRAG_MODE && !scrollingPanPointerDown && DRAGTHRESHOLDREACHED) {
+                if (const auto WORKSPACE = workspaceAtOverviewPoint(dragStartMouseLocal); isWorkspaceScrolling(WORKSPACE)) {
+                    beginScrollingPan(WORKSPACE);
+                    scrollingPanLastMouseLocal = dragStartMouseLocal;
+                    updateScrollingPan();
+                }
+            }
+        }
 
         if (dragPendingPrimary) {
             const float DRAGTHRESHOLD = ScrollOverview::Config::getValue<int>("binds:drag_threshold") * (pMonitor ? pMonitor->m_scale : 1.F);
@@ -950,10 +1016,17 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
         if (closing)
             return;
 
-        if (!dragPendingPrimary && !resizePointerDown && !scrollingPanPointerDown && !dragActiveWindow && !resizeActiveWindow && isPointerOnTopLayer(pMonitor.lock()))
+        if (!dragPendingPrimary && !resizePointerDown && !scrollingPanPointerDown && !dragActiveWindow && !resizeActiveWindow && isPointerOnTopLayer(pMonitor.lock())) {
+            submapMouseClickPending = false;
+            submapMouseClickButton  = 0;
+            submapMouseClickKeybind.reset();
             return;
+        }
 
         info.cancelled = true;
+        Config::Actions::state()->m_lastMouseCode = event.button;
+        Config::Actions::state()->m_lastCode      = 0;
+        Config::Actions::state()->m_timeLastMs    = event.timeMs;
         // Without releasing buttons, mouse-triggered overview consumes release
         // events
         // before they reach Hyprland's input manager, leaving it stuck thinking
@@ -965,12 +1038,25 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
         const uint32_t RESIZE_BUTTON      = LEFT_HANDED ? BTN_LEFT : BTN_RIGHT;
         const bool     INVERT_DRAG_MODE   = ScrollOverview::Config::getDragMode() == 1;
         const uint32_t SECONDARY_DRAG_BUTTON = BTN_MIDDLE;
+        const auto     clearSubmapMouseClickPending = [&]() {
+            submapMouseClickPending = false;
+            submapMouseClickButton  = 0;
+            submapMouseClickKeybind.reset();
+        };
 
         if (event.button == MAIN_BUTTON) {
             lastMousePosLocal = getOverviewMousePosLocal(pMonitor.lock());
 
             if (event.state == WL_POINTER_BUTTON_STATE_PRESSED) {
-                dragPendingPrimary = true;
+                if (const auto KEYBIND = findOverviewSubmapMouseClick(event.button); submapActive && KEYBIND) {
+                    submapMouseClickPending = true;
+                    submapMouseClickButton  = event.button;
+                    submapMouseClickKeybind = KEYBIND;
+                    dragStartMouseLocal     = lastMousePosLocal;
+                    return;
+                }
+
+                dragPendingPrimary  = true;
                 dragStartMouseLocal = lastMousePosLocal;
                 return;
             }
@@ -979,17 +1065,49 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
             if (scrollingPanPointerDown)
                 endScrollingPan();
 
+            const bool  WASPENDINGCLICK         = submapMouseClickPending && submapMouseClickButton == event.button;
+            const auto   PENDINGKEYBIND          = submapMouseClickKeybind;
+            const float CLICK_MAX_DRAG_DISTANCE = 10.F * (pMonitor ? pMonitor->m_scale : 1.F);
+            const auto   performClickAction      = [&]() {
+                if (WASPENDINGCLICK) {
+                    dispatchSubmapMouseClick(event.button, PENDINGKEYBIND);
+                    return;
+                }
+
+                if (dispatchSubmapMouseClick(event.button))
+                    return;
+
+                selectWindowAtOverviewCursor();
+                close();
+            };
+
             if (dragActiveWindow) {
+                if (dragStartMouseLocal.distanceSq(lastMousePosLocal) < CLICK_MAX_DRAG_DISTANCE * CLICK_MAX_DRAG_DISTANCE) {
+                    clearDragPending();
+                    dragActiveWindow.reset();
+                    dragOriginalWorkspace.reset();
+                    dragStartedTiled      = false;
+                    dragOriginalFloatSize = Vector2D{};
+                    dragGrabOffsetLocal   = Vector2D{};
+                    dragOriginalBox       = CBox{};
+                    clearSubmapMouseClickPending();
+
+                    if (!WASPANNING)
+                        performClickAction();
+
+                    return;
+                }
+
                 endWindowDrag();
+                clearSubmapMouseClickPending();
                 return;
             }
 
             clearDragPending();
+            clearSubmapMouseClickPending();
 
-            if (!WASPANNING) {
-                selectHoveredWorkspace();
-                close();
-            }
+            if (!WASPANNING)
+                performClickAction();
             return;
         }
 
@@ -997,6 +1115,14 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
             lastMousePosLocal = getOverviewMousePosLocal(pMonitor.lock());
 
             if (event.state == WL_POINTER_BUTTON_STATE_PRESSED) {
+                if (const auto KEYBIND = findOverviewSubmapMouseClick(event.button); submapActive && KEYBIND) {
+                    submapMouseClickPending = true;
+                    submapMouseClickButton  = event.button;
+                    submapMouseClickKeybind = KEYBIND;
+                    dragStartMouseLocal     = lastMousePosLocal;
+                    return;
+                }
+
                 size_t workspaceIdx = 0;
                 const auto WORKSPACE = workspaceAtOverviewCursor(&workspaceIdx);
                 if (!isWorkspaceScrolling(WORKSPACE)) {
@@ -1005,6 +1131,22 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
                 }
 
                 beginScrollingPan(WORKSPACE);
+                return;
+            }
+
+            if (submapMouseClickPending && submapMouseClickButton == event.button) {
+                const bool WASPANNING = scrollingPanPointerDown;
+                const auto KEYBIND    = submapMouseClickKeybind;
+                if (scrollingPanPointerDown)
+                    endScrollingPan();
+
+                submapMouseClickPending = false;
+                submapMouseClickButton  = 0;
+                submapMouseClickKeybind.reset();
+
+                if (!WASPANNING)
+                    dispatchSubmapMouseClick(event.button, KEYBIND);
+
                 return;
             }
 
@@ -1017,6 +1159,12 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
             lastMousePosLocal = getOverviewMousePosLocal(pMonitor.lock());
 
             if (event.state == WL_POINTER_BUTTON_STATE_PRESSED) {
+                if (const auto KEYBIND = findOverviewSubmapMouseClick(event.button); submapActive && KEYBIND) {
+                    submapMouseClickPending = true;
+                    submapMouseClickButton  = event.button;
+                    submapMouseClickKeybind = KEYBIND;
+                }
+
                 size_t resizeWorkspace = 0;
                 const auto window      = windowAtOverviewCursor(&resizeWorkspace);
                 if (!shouldShowOverviewWindow(window) || shouldShowPinnedFloatingOverviewWindow(window)) {
@@ -1043,11 +1191,22 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
 
             if (resizeActiveWindow) {
                 endWindowResize();
+                clearSubmapMouseClickPending();
                 return;
             }
 
+            const bool WASPENDINGCLICK = submapMouseClickPending && submapMouseClickButton == event.button;
+            const auto PENDINGKEYBIND  = submapMouseClickKeybind;
             resizePointerDown = false;
             resizePendingWindow.reset();
+
+            if (WASPENDINGCLICK) {
+                clearSubmapMouseClickPending();
+                dispatchSubmapMouseClick(event.button, PENDINGKEYBIND);
+                return;
+            }
+
+            clearSubmapMouseClickPending();
             return;
         }
 
@@ -1073,7 +1232,10 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
             dragGrabOffsetLocal   = Vector2D{};
             dragOriginalBox       = CBox{};
 
-            selectHoveredWorkspace();
+            if (dispatchSubmapMouseClick(event.button))
+                return;
+
+            selectWindowAtOverviewCursor();
             close();
             return;
         }
@@ -1085,7 +1247,10 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
 
         clearDragPending();
 
-        selectHoveredWorkspace();
+        if (dispatchSubmapMouseClick(event.button))
+            return;
+
+        selectWindowAtOverviewCursor();
 
         close();
     };
@@ -1099,7 +1264,7 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
 
         info.cancelled = true;
 
-        selectHoveredWorkspace();
+        selectWindowAtOverviewCursor();
 
         close();
     };
@@ -1244,23 +1409,19 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
         switch (KEYSYM) {
             case XKB_KEY_Left:
             case XKB_KEY_KP_Left:
-                if (!moveWindowSelection("l") && layout == ScrollOverview::Config::ELayout::HORIZONTAL)
-                    moveViewportWorkspace(false);
+                moveSelection("left");
                 break;
             case XKB_KEY_Right:
             case XKB_KEY_KP_Right:
-                if (!moveWindowSelection("r") && layout == ScrollOverview::Config::ELayout::HORIZONTAL)
-                    moveViewportWorkspace(true);
+                moveSelection("right");
                 break;
             case XKB_KEY_Up:
             case XKB_KEY_KP_Up:
-                if (!moveWindowSelection("u") && layout != ScrollOverview::Config::ELayout::HORIZONTAL)
-                    moveViewportWorkspace(false);
+                moveSelection("up");
                 break;
             case XKB_KEY_Down:
             case XKB_KEY_KP_Down:
-                if (!moveWindowSelection("d") && layout != ScrollOverview::Config::ELayout::HORIZONTAL)
-                    moveViewportWorkspace(true);
+                moveSelection("down");
                 break;
             case XKB_KEY_Return:
             case XKB_KEY_KP_Enter: close(); break;
@@ -1285,7 +1446,9 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
     workspaceCreatedHook = Event::bus()->m_events.workspace.created.listen(onWorkspaceLifecycle);
     workspaceRemovedHook = Event::bus()->m_events.workspace.removed.listen(onWorkspaceLifecycle);
     workspaceActiveHook  = Event::bus()->m_events.workspace.active.listen(onWorkspaceActive);
-    keyboardKeyHook     = Event::bus()->m_events.input.keyboard.key.listen(onKeyboardKey);
+    activateSubmapIfConfigured();
+    if (!usesSubmapKeybinds)
+        keyboardKeyHook = Event::bus()->m_events.input.keyboard.key.listen(onKeyboardKey);
 
     Cursor::overrideController->setOverride("left_ptr", Cursor::CURSOR_OVERRIDE_SPECIAL_ACTION);
 
@@ -1789,14 +1952,36 @@ PHLWORKSPACE CScrollOverview::workspaceAtOverviewCursor(size_t* hoveredWorkspace
     return workspaceAtOverviewPoint(lastMousePosLocal, hoveredWorkspaceIdx);
 }
 
+bool CScrollOverview::selectOverviewWindow(PHLWINDOW window, size_t workspaceIdx, bool syncFocus) {
+    if (!window)
+        return false;
+
+    closeOnWindow            = window;
+    viewportCurrentWorkspace = workspaceIdx;
+    rememberSelection(window);
+    if (syncFocus)
+        syncFocusedSelection();
+    damage();
+    return true;
+}
+
+bool CScrollOverview::selectWindowAtOverviewCursor(bool syncFocus) {
+    lastMousePosLocal = getOverviewMousePosLocal(pMonitor.lock());
+
+    size_t    workspaceIdx = viewportCurrentWorkspace;
+    PHLWINDOW window       = windowAtOverviewCursor(&workspaceIdx);
+
+    return selectOverviewWindow(window, workspaceIdx, syncFocus);
+}
+
 void CScrollOverview::selectHoveredWorkspace() {
+    lastMousePosLocal = getOverviewMousePosLocal(pMonitor.lock());
+
     size_t    workspaceIdx = 0;
     PHLWINDOW window       = windowAtOverviewCursor(&workspaceIdx);
 
     if (window) {
-        closeOnWindow            = window;
-        viewportCurrentWorkspace = workspaceIdx;
-        rememberSelection(window);
+        selectOverviewWindow(window, workspaceIdx);
         return;
     }
 
@@ -1821,6 +2006,35 @@ void CScrollOverview::selectHoveredWorkspace() {
         viewportCurrentWorkspace = i;
         return;
     }
+}
+
+bool CScrollOverview::windowDispatcherAction(const std::string& action) {
+    const auto CURRENTKEYBIND = g_pKeybindManager ? g_pKeybindManager->m_currentKeybind : SP<SKeybind>{};
+    const bool FROMMOUSEBIND  = CURRENTKEYBIND && CURRENTKEYBIND->key.starts_with("mouse:");
+
+    PHLWINDOW WINDOW;
+    size_t    workspaceIdx = viewportCurrentWorkspace;
+
+    if (FROMMOUSEBIND) {
+        lastMousePosLocal = getOverviewMousePosLocal(pMonitor.lock());
+        WINDOW            = windowAtOverviewCursor(&workspaceIdx);
+    } else
+        WINDOW = getOverviewWindowToShow(closeOnWindow.lock());
+
+    if (!WINDOW)
+        return false;
+
+    if (action == "select") {
+        return selectOverviewWindow(WINDOW, workspaceIdx, true);
+    }
+
+    if (action == "close") {
+        WINDOW->sendClose();
+        damage();
+        return true;
+    }
+
+    return false;
 }
 
 Vector2D CScrollOverview::overviewPointToGlobal(size_t workspaceIdx, const Vector2D& pointLocal) const {
@@ -2605,7 +2819,12 @@ void CScrollOverview::syncFocusedSelection() {
     if (Desktop::focusState()->window() == window && window->m_workspace == pMonitor->m_activeWorkspace)
         return;
 
+    const auto PREVIOUSWORKSPACE = pMonitor ? pMonitor->m_activeWorkspace : PHLWORKSPACE{};
+
     Desktop::focusState()->fullWindowFocus(window, Desktop::FOCUS_REASON_KEYBIND);
+
+    if (window->m_workspace != PREVIOUSWORKSPACE)
+        focusSyncedFromWorkspaceID = PREVIOUSWORKSPACE ? PREVIOUSWORKSPACE->m_id : WORKSPACE_INVALID;
 }
 
 size_t CScrollOverview::dragWorkspaceIndex(PHLWINDOW window) const {
@@ -2623,35 +2842,35 @@ size_t CScrollOverview::dragWorkspaceIndex(PHLWINDOW window) const {
     return images.size();
 }
 
-bool CScrollOverview::moveWindowSelection(const std::string& direction) {
-    if (images.empty() || viewportCurrentWorkspace >= images.size() || direction.empty())
-        return false;
-
-    const bool MOVINGLEFT  = direction == "l";
-    const bool MOVINGRIGHT = direction == "r";
-    const bool MOVINGUP    = direction == "u";
-    const bool MOVINGDOWN  = direction == "d";
+bool CScrollOverview::moveSelection(const std::string& direction) {
+    const bool MOVINGLEFT  = direction == "left";
+    const bool MOVINGRIGHT = direction == "right";
+    const bool MOVINGUP    = direction == "up";
+    const bool MOVINGDOWN  = direction == "down";
 
     if (!MOVINGLEFT && !MOVINGRIGHT && !MOVINGUP && !MOVINGDOWN)
         return false;
 
-    const auto& WORKSPACEIMAGE = images[viewportCurrentWorkspace];
-    if (!WORKSPACEIMAGE || !WORKSPACEIMAGE->pWorkspace)
-        return false;
+    bool shouldMoveWorkspace = images.empty() || viewportCurrentWorkspace >= images.size();
 
-    if (!closeOnWindow || closeOnWindow->m_workspace != WORKSPACEIMAGE->pWorkspace || !shouldShowOverviewWindow(closeOnWindow.lock()) || closeOnWindow->m_isFloating) {
+    const auto WORKSPACEIMAGE = shouldMoveWorkspace ? SP<SWorkspaceImage>{} : images[viewportCurrentWorkspace];
+    if (!WORKSPACEIMAGE || !WORKSPACEIMAGE->pWorkspace)
+        shouldMoveWorkspace = true;
+
+    if (!shouldMoveWorkspace && (!closeOnWindow || closeOnWindow->m_workspace != WORKSPACEIMAGE->pWorkspace || !shouldShowOverviewWindow(closeOnWindow.lock()) || closeOnWindow->m_isFloating)) {
         syncSelectionToViewport();
         if (!closeOnWindow || closeOnWindow->m_workspace != WORKSPACEIMAGE->pWorkspace || !shouldShowOverviewWindow(closeOnWindow.lock()) || closeOnWindow->m_isFloating)
-            return false;
+            shouldMoveWorkspace = true;
     }
 
     const auto CURRENT = getOverviewWindowToShow(closeOnWindow.lock());
     if (!CURRENT)
-        return false;
+        shouldMoveWorkspace = true;
 
-    closeOnWindow = CURRENT;
+    if (!shouldMoveWorkspace)
+        closeOnWindow = CURRENT;
 
-    const auto CURRENTCENTER = CURRENT->middle();
+    const auto CURRENTCENTER = shouldMoveWorkspace ? Vector2D{} : CURRENT->middle();
 
     PHLWINDOW bestCandidate;
     float     bestPrimaryDistance   = std::numeric_limits<float>::max();
@@ -2659,7 +2878,7 @@ bool CScrollOverview::moveWindowSelection(const std::string& direction) {
     float     bestOverlap           = -1.F;
     bool      bestHasOverlap         = false;
 
-    for (const auto& windowRef : WORKSPACEIMAGE->windows) {
+    for (const auto& windowRef : shouldMoveWorkspace ? std::vector<PHLWINDOWREF>{} : WORKSPACEIMAGE->windows) {
         const auto WINDOW = getOverviewWindowToShow(windowRef.lock());
         if (!shouldShowOverviewWindow(WINDOW) || WINDOW == CURRENT || WINDOW->m_isFloating)
             continue;
@@ -2722,8 +2941,17 @@ bool CScrollOverview::moveWindowSelection(const std::string& direction) {
         }
     }
 
-    if (!bestCandidate)
-        return false;
+    const bool WINDOWSELECTIONMOVED = bestCandidate;
+    if (!WINDOWSELECTIONMOVED)
+        shouldMoveWorkspace = true;
+
+    if (shouldMoveWorkspace) {
+        if (((MOVINGLEFT || MOVINGRIGHT) && layout != ScrollOverview::Config::ELayout::HORIZONTAL) || ((MOVINGUP || MOVINGDOWN) && layout == ScrollOverview::Config::ELayout::HORIZONTAL))
+            return false;
+
+        moveViewportWorkspace(MOVINGRIGHT || MOVINGDOWN);
+        return true;
+    }
 
     closeOnWindow = bestCandidate;
     rememberSelection(bestCandidate);
@@ -3799,6 +4027,19 @@ void CScrollOverview::close() {
     const auto SELECTEDWORKSPACE =
         viewportCurrentWorkspace < images.size() && images[viewportCurrentWorkspace] ? images[viewportCurrentWorkspace]->pWorkspace : PHLWORKSPACE{};
 
+    const auto finishClose = [&](const PHLWORKSPACE& finalWorkspace, const PHLWINDOW& finalWindow) {
+        emitFullscreenVisibilityState(getOverviewFullscreenVisibilityWindow(finalWorkspace, finalWindow), false);
+
+        *scale = 1.F;
+
+        if (!ScrollOverview::Config::getValue<int>("animations:enabled")) {
+            forceWorkspaceWindowsDecoRecalc(finalWorkspace ? finalWorkspace : pMonitor->m_activeWorkspace);
+            damage();
+        }
+
+        scale->setCallbackOnEnd(removeOverview);
+    };
+
     if (!closeOnWindow && (!SELECTEDWORKSPACE || SELECTEDWORKSPACE == pMonitor->m_activeWorkspace)) {
         const auto FOCUSEDWINDOW = getOverviewWindowToShow(Desktop::focusState()->window());
         if (!SELECTEDWORKSPACE || (FOCUSEDWINDOW && FOCUSEDWINDOW->m_workspace == SELECTEDWORKSPACE))
@@ -3806,6 +4047,42 @@ void CScrollOverview::close() {
     }
 
     closeOnWindow = getOverviewWindowToShow(closeOnWindow.lock());
+
+    if (closeOnWindow && focusSyncedFromWorkspaceID != WORKSPACE_INVALID) {
+        const auto FINALWORKSPACE = closeOnWindow->m_workspace;
+        size_t     sourceIdx      = images.size();
+        size_t     targetIdx      = images.size();
+
+        for (size_t workspaceIdx = 0; workspaceIdx < images.size(); ++workspaceIdx) {
+            if (!images[workspaceIdx] || !images[workspaceIdx]->pWorkspace)
+                continue;
+
+            if (images[workspaceIdx]->pWorkspace->m_id == focusSyncedFromWorkspaceID)
+                sourceIdx = workspaceIdx;
+            if (images[workspaceIdx]->pWorkspace == FINALWORKSPACE)
+                targetIdx = workspaceIdx;
+        }
+
+        if (sourceIdx < images.size() && targetIdx < images.size()) {
+            if (FINALWORKSPACE != pMonitor->m_activeWorkspace)
+                pMonitor->changeWorkspace(FINALWORKSPACE, false, true, true);
+
+            Desktop::focusState()->fullWindowFocus(closeOnWindow.lock(), Desktop::FOCUS_REASON_DESKTOP_STATE_CHANGE);
+
+            startedOn                = FINALWORKSPACE;
+            viewportCurrentWorkspace = targetIdx;
+
+            const auto FINALPITCH = getWorkspaceLogicalPitch(pMonitor.lock(), 1.F, layout);
+            viewOffset->setValueAndWarp(axisOffsetVector(workspaceOverviewLogicalOffset(sourceIdx, targetIdx, FINALPITCH), layout));
+            *viewOffset = Vector2D{};
+
+            focusSyncedFromWorkspaceID = WORKSPACE_INVALID;
+
+            const auto FINALWINDOW = getOverviewWindowToShow(closeOnWindow.lock());
+            finishClose(FINALWORKSPACE, FINALWINDOW);
+            return;
+        }
+    }
 
     if (!closeOnWindow) {
         const auto ACTIVEIDX = activeWorkspaceIndex();
@@ -3822,9 +4099,22 @@ void CScrollOverview::close() {
 
         if (SELECTEDWORKSPACE && SELECTEDWORKSPACE != pMonitor->m_activeWorkspace)
             pMonitor->changeWorkspace(SELECTEDWORKSPACE, false, true, true);
-    } else if (closeOnWindow == Desktop::focusState()->window() && closeOnWindow->m_workspace == pMonitor->m_activeWorkspace)
+    } else if (closeOnWindow == Desktop::focusState()->window() && closeOnWindow->m_workspace == pMonitor->m_activeWorkspace) {
+        if (focusSyncedFromWorkspaceID != WORKSPACE_INVALID) {
+            const auto ACTIVEIDX   = activeWorkspaceIndex();
+            const auto FINALPITCH = getWorkspaceLogicalPitch(pMonitor.lock(), 1.F, layout);
+
+            for (size_t workspaceIdx = 0; workspaceIdx < images.size(); ++workspaceIdx) {
+                if (!images[workspaceIdx] || !images[workspaceIdx]->pWorkspace || images[workspaceIdx]->pWorkspace->m_id != focusSyncedFromWorkspaceID)
+                    continue;
+
+                viewOffset->setValueAndWarp(axisOffsetVector(workspaceOverviewLogicalOffset(workspaceIdx, ACTIVEIDX, FINALPITCH), layout));
+                break;
+            }
+        }
+
         *viewOffset = Vector2D{};
-    else {
+    } else {
 
         if (closeOnWindow->m_workspace != pMonitor->m_activeWorkspace)
             pMonitor->changeWorkspace(closeOnWindow->m_workspace, false, true, true);
@@ -3850,18 +4140,11 @@ void CScrollOverview::close() {
         }
     }
 
+    focusSyncedFromWorkspaceID = WORKSPACE_INVALID;
+
     const auto FINALWINDOW    = getOverviewWindowToShow(closeOnWindow.lock());
     const auto FINALWORKSPACE = FINALWINDOW ? FINALWINDOW->m_workspace : SELECTEDWORKSPACE;
-    emitFullscreenVisibilityState(getOverviewFullscreenVisibilityWindow(FINALWORKSPACE, FINALWINDOW), false);
-
-    *scale = 1.F;
-
-    if (!ScrollOverview::Config::getValue<int>("animations:enabled")) {
-        forceWorkspaceWindowsDecoRecalc(FINALWORKSPACE ? FINALWORKSPACE : pMonitor->m_activeWorkspace);
-        damage();
-    }
-
-    scale->setCallbackOnEnd(removeOverview);
+    finishClose(FINALWORKSPACE, FINALWINDOW);
 }
 
 void CScrollOverview::onPreRender() {
@@ -3879,9 +4162,12 @@ void CScrollOverview::onPreRender() {
         rebuildPending       = false;
         markBlurDirty();
         onWorkspaceChange();
+        focusSyncedFromWorkspaceID = WORKSPACE_INVALID;
         emitFullscreenVisibilityState(Desktop::focusState()->window(), true);
         return;
     }
+
+    focusSyncedFromWorkspaceID = WORKSPACE_INVALID;
 
     if (rebuildPending) {
         rebuildPending = false;
@@ -4086,6 +4372,7 @@ void CScrollOverview::setClosing(bool closing_) {
     closing = closing_;
     if (closing) {
         inputFramePending = false;
+        restoreSubmapIfActive();
         releaseInputListeners();
         restoreWorkspaceAnimationOverrides();
     } else
@@ -4096,6 +4383,9 @@ void CScrollOverview::releaseInputListeners() {
     if (scrollingPanPointerDown)
         endScrollingPan();
     clearDragPending();
+    submapMouseClickPending = false;
+    submapMouseClickButton  = 0;
+    submapMouseClickKeybind.reset();
 
     mouseMoveHook.reset();
     touchMoveHook.reset();
@@ -4103,6 +4393,66 @@ void CScrollOverview::releaseInputListeners() {
     mouseButtonHook.reset();
     touchDownHook.reset();
     keyboardKeyHook.reset();
+}
+
+void CScrollOverview::activateSubmapIfConfigured() {
+    if (!usesSubmapKeybinds || !g_pKeybindManager)
+        return;
+
+    previousSubmapName = g_pKeybindManager->getCurrentSubmap().name;
+
+    const auto DISPATCHER = g_pKeybindManager->m_dispatchers.find("submap");
+    if (DISPATCHER == g_pKeybindManager->m_dispatchers.end()) {
+        usesSubmapKeybinds = false;
+        return;
+    }
+
+    const auto RESULT = DISPATCHER->second(OVERVIEW_SUBMAP);
+    if (!RESULT.success) {
+        usesSubmapKeybinds = false;
+        return;
+    }
+
+    submapActive = true;
+}
+
+void CScrollOverview::restoreSubmapIfActive() {
+    if (!submapActive || !g_pKeybindManager)
+        return;
+
+    const auto CURRENT = g_pKeybindManager->getCurrentSubmap().name;
+    if (CURRENT == OVERVIEW_SUBMAP) {
+        const auto DISPATCHER = g_pKeybindManager->m_dispatchers.find("submap");
+        if (DISPATCHER != g_pKeybindManager->m_dispatchers.end())
+            DISPATCHER->second(previousSubmapName.empty() ? "reset" : previousSubmapName);
+    }
+
+    submapActive = false;
+}
+
+bool CScrollOverview::dispatchSubmapMouseClick(uint32_t button, const SP<SKeybind>& keybind) {
+    if (!submapActive || !g_pKeybindManager)
+        return false;
+
+    const auto KEYBIND = keybind ? keybind : findOverviewSubmapMouseClick(button);
+    if (!KEYBIND)
+        return false;
+
+    const auto DISPATCHERNAME = KEYBIND->mouse ? "mouse" : KEYBIND->handler;
+    const auto DISPATCHER     = g_pKeybindManager->m_dispatchers.find(DISPATCHERNAME);
+    if (DISPATCHER == g_pKeybindManager->m_dispatchers.end())
+        return false;
+
+    const auto PREVIOUSKEYBIND = g_pKeybindManager->m_currentKeybind;
+    g_pKeybindManager->m_currentKeybind = KEYBIND;
+    auto restoreKeybind = Hyprutils::Utils::CScopeGuard([PREVIOUSKEYBIND] { g_pKeybindManager->m_currentKeybind = PREVIOUSKEYBIND; });
+
+    const int PREVIOUSPASSPRESSED = Config::Actions::state()->m_passPressed;
+    Config::Actions::state()->m_passPressed = 0;
+    auto restorePassPressed = Hyprutils::Utils::CScopeGuard([PREVIOUSPASSPRESSED] { Config::Actions::state()->m_passPressed = PREVIOUSPASSPRESSED; });
+
+    DISPATCHER->second(KEYBIND->mouse ? "0" + KEYBIND->arg : KEYBIND->arg);
+    return true;
 }
 
 void CScrollOverview::resetSwipe() {

--- a/scrollOverview.cpp
+++ b/scrollOverview.cpp
@@ -1042,6 +1042,14 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
 
             return !submapActive;
         };
+        const auto     performClickAction = [&](uint32_t button) {
+            if (!shouldRunDefaultClickAction(button))
+                return;
+
+            selectHoveredWorkspace();
+            selectWindowAtOverviewCursor(true);
+            close();
+        };
 
         if (event.button == MAIN_BUTTON) {
             lastMousePosLocal = getOverviewMousePosLocal(pMonitor.lock());
@@ -1060,13 +1068,6 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
                 endScrollingPan();
 
             const float CLICK_MAX_DRAG_DISTANCE = 10.F * (pMonitor ? pMonitor->m_scale : 1.F);
-            const auto   performClickAction      = [&]() {
-                if (!shouldRunDefaultClickAction(event.button))
-                    return;
-
-                selectWindowAtOverviewCursor();
-                close();
-            };
 
             if (dragActiveWindow) {
                 if (dragStartMouseLocal.distanceSq(lastMousePosLocal) < CLICK_MAX_DRAG_DISTANCE * CLICK_MAX_DRAG_DISTANCE) {
@@ -1079,7 +1080,7 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
                     dragOriginalBox       = CBox{};
 
                     if (!WASPANNING)
-                        performClickAction();
+                        performClickAction(event.button);
                     else
                         clearSubmapMouseClickPending();
 
@@ -1094,7 +1095,7 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
             clearDragPending();
 
             if (!WASPANNING)
-                performClickAction();
+                performClickAction(event.button);
             else
                 clearSubmapMouseClickPending();
             return;
@@ -1204,11 +1205,7 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
             dragGrabOffsetLocal   = Vector2D{};
             dragOriginalBox       = CBox{};
 
-            if (!shouldRunDefaultClickAction(event.button))
-                return;
-
-            selectWindowAtOverviewCursor();
-            close();
+            performClickAction(event.button);
             return;
         }
 
@@ -1219,12 +1216,7 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
 
         clearDragPending();
 
-        if (!shouldRunDefaultClickAction(event.button))
-            return;
-
-        selectWindowAtOverviewCursor();
-
-        close();
+        performClickAction(event.button);
     };
 
     auto onCursorSelect = [this](auto, Event::SCallbackInfo& info) {
@@ -1949,35 +1941,21 @@ bool CScrollOverview::selectWindowAtOverviewCursor(bool syncFocus) {
 void CScrollOverview::selectHoveredWorkspace() {
     lastMousePosLocal = getOverviewMousePosLocal(pMonitor.lock());
 
-    size_t    workspaceIdx = 0;
-    PHLWINDOW window       = windowAtOverviewCursor(&workspaceIdx);
-
-    if (window) {
-        selectOverviewWindow(window, workspaceIdx);
+    size_t     workspaceIdx = viewportCurrentWorkspace;
+    const auto WORKSPACE    = workspaceAtOverviewCursor(&workspaceIdx);
+    if (!WORKSPACE)
         return;
+
+    closeOnWindow.reset();
+    viewportCurrentWorkspace = workspaceIdx;
+
+    if (pMonitor && pMonitor->m_activeWorkspace != WORKSPACE) {
+        if (focusSyncedFromWorkspaceID == WORKSPACE_INVALID)
+            focusSyncedFromWorkspaceID = pMonitor->m_activeWorkspace ? pMonitor->m_activeWorkspace->m_id : WORKSPACE_INVALID;
+        pMonitor->changeWorkspace(WORKSPACE, false, true, true);
     }
 
-    const auto MONITOR = pMonitor.lock();
-    if (!MONITOR)
-        return;
-
-    const auto ACTIVEIDX = activeWorkspaceIndex();
-    const auto PITCH     = getWorkspaceRenderedPitch(MONITOR, scale->value(), layout);
-
-    for (size_t i = 0; i < images.size(); ++i) {
-        const auto& wimg = images[i];
-        if (!wimg || !wimg->pWorkspace)
-            continue;
-
-        const auto offset = workspaceOverviewOffset(i, ACTIVEIDX, PITCH);
-        const auto box  = getOverviewWorkspaceBox(MONITOR, scale->value(), viewOffset->value(), offset, layout);
-        if (!box.containsPoint(lastMousePosLocal))
-            continue;
-
-        closeOnWindow.reset();
-        viewportCurrentWorkspace = i;
-        return;
-    }
+    damage();
 }
 
 bool CScrollOverview::windowDispatcherAction(const std::string& action) {
@@ -1996,9 +1974,8 @@ bool CScrollOverview::windowDispatcherAction(const std::string& action) {
     if (!WINDOW)
         return false;
 
-    if (action == "select") {
+    if (action == "select")
         return selectOverviewWindow(WINDOW, workspaceIdx, true);
-    }
 
     if (action == "close") {
         WINDOW->sendClose();
@@ -2795,7 +2772,7 @@ void CScrollOverview::syncFocusedSelection() {
 
     Desktop::focusState()->fullWindowFocus(window, Desktop::FOCUS_REASON_KEYBIND);
 
-    if (window->m_workspace != PREVIOUSWORKSPACE)
+    if (window->m_workspace != PREVIOUSWORKSPACE && focusSyncedFromWorkspaceID == WORKSPACE_INVALID)
         focusSyncedFromWorkspaceID = PREVIOUSWORKSPACE ? PREVIOUSWORKSPACE->m_id : WORKSPACE_INVALID;
 }
 

--- a/scrollOverview.cpp
+++ b/scrollOverview.cpp
@@ -96,29 +96,6 @@ static bool hasOverviewSubmap() {
     return g_pKeybindManager && std::ranges::any_of(g_pKeybindManager->m_keybinds, [](const auto& keybind) { return keybind && keybind->submap.name == OVERVIEW_SUBMAP; });
 }
 
-static SP<SKeybind> findOverviewSubmapMouseClick(uint32_t button) {
-    if (!g_pKeybindManager || !g_pInputManager)
-        return {};
-
-    const auto KEYNAME = "mouse:" + std::to_string(button);
-    const auto MODS    = g_pInputManager->getModsFromAllKBs();
-
-    for (const auto& keybind : g_pKeybindManager->m_keybinds) {
-        if (!keybind || !keybind->enabled || keybind->shadowed || keybind->key != KEYNAME)
-            continue;
-
-        if (keybind->submap.name != OVERVIEW_SUBMAP)
-            continue;
-
-        if (keybind->modmask != MODS && !keybind->ignoreMods)
-            continue;
-
-        return keybind;
-    }
-
-    return {};
-}
-
 static bool isTopLayerFocused(PHLMONITOR monitor) {
     const auto FOCUSEDSURFACE = g_pSeatManager->m_state.keyboardFocus.lock();
 
@@ -929,12 +906,18 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
         if (closing)
             return;
 
+        const bool     LEFT_HANDED           = ScrollOverview::Config::getLeftHanded();
+        const uint32_t MAIN_BUTTON           = LEFT_HANDED ? BTN_RIGHT : BTN_LEFT;
+        const bool     INVERT_DRAG_MODE      = ScrollOverview::Config::getDragMode() == 1;
+        const uint32_t SECONDARY_DRAG_BUTTON = BTN_MIDDLE;
+        const float    DRAGTHRESHOLD         = ScrollOverview::Config::getDragThreshold() * (pMonitor ? pMonitor->m_scale : 1.F);
+        const float    DRAGTHRESHOLDSQ       = std::pow(DRAGTHRESHOLD, 2);
+
         lastMousePosLocal = getOverviewMousePosLocal(pMonitor.lock());
 
         if (!dragPendingPrimary && !resizePointerDown && !scrollingPanPointerDown && !dragActiveWindow && !resizeActiveWindow && isPointerOnTopLayer(pMonitor.lock())) {
             submapMouseClickPending = false;
             submapMouseClickButton  = 0;
-            submapMouseClickKeybind.reset();
             return;
         }
 
@@ -942,19 +925,13 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
         requestInputFrame();
 
         if (submapMouseClickPending) {
-            const bool     LEFT_HANDED          = ScrollOverview::Config::getLeftHanded();
-            const uint32_t MAIN_BUTTON          = LEFT_HANDED ? BTN_RIGHT : BTN_LEFT;
-            const bool     INVERT_DRAG_MODE     = ScrollOverview::Config::getDragMode() == 1;
-            const uint32_t SECONDARY_DRAG_BUTTON = BTN_MIDDLE;
-            const float    DRAGTHRESHOLD        = ScrollOverview::Config::getValue<int>("binds:drag_threshold") * (pMonitor ? pMonitor->m_scale : 1.F);
-            const bool     DRAGTHRESHOLDREACHED = dragStartMouseLocal.distanceSq(lastMousePosLocal) > std::pow(DRAGTHRESHOLD, 2);
+            const bool DRAGTHRESHOLDREACHED = dragStartMouseLocal.distanceSq(lastMousePosLocal) > DRAGTHRESHOLDSQ;
 
             if (submapMouseClickButton == MAIN_BUTTON && !dragActiveWindow && !scrollingPanPointerDown && DRAGTHRESHOLDREACHED) {
                 submapMouseClickPending = false;
                 submapMouseClickButton  = 0;
-                submapMouseClickKeybind.reset();
 
-                if (ScrollOverview::Config::getDragMode() == 0)
+                if (!INVERT_DRAG_MODE)
                     beginWindowDrag(windowAtOverviewPoint(dragStartMouseLocal));
                 else if (const auto WORKSPACE = workspaceAtOverviewPoint(dragStartMouseLocal); isWorkspaceScrolling(WORKSPACE)) {
                     beginScrollingPan(WORKSPACE);
@@ -965,17 +942,24 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
 
             if (submapMouseClickButton == SECONDARY_DRAG_BUTTON && !INVERT_DRAG_MODE && !scrollingPanPointerDown && DRAGTHRESHOLDREACHED) {
                 if (const auto WORKSPACE = workspaceAtOverviewPoint(dragStartMouseLocal); isWorkspaceScrolling(WORKSPACE)) {
+                    submapMouseClickPending = false;
+                    submapMouseClickButton  = 0;
                     beginScrollingPan(WORKSPACE);
                     scrollingPanLastMouseLocal = dragStartMouseLocal;
                     updateScrollingPan();
                 }
             }
+
+            if (submapMouseClickButton == SECONDARY_DRAG_BUTTON && INVERT_DRAG_MODE && !dragActiveWindow && DRAGTHRESHOLDREACHED) {
+                submapMouseClickPending = false;
+                submapMouseClickButton  = 0;
+                beginWindowDrag(windowAtOverviewPoint(dragStartMouseLocal));
+            }
         }
 
         if (dragPendingPrimary) {
-            const float DRAGTHRESHOLD = ScrollOverview::Config::getValue<int>("binds:drag_threshold") * (pMonitor ? pMonitor->m_scale : 1.F);
-            if (!dragActiveWindow && !scrollingPanPointerDown && dragStartMouseLocal.distanceSq(lastMousePosLocal) > std::pow(DRAGTHRESHOLD, 2)) {
-                if (ScrollOverview::Config::getDragMode() == 0) {
+            if (!dragActiveWindow && !scrollingPanPointerDown && dragStartMouseLocal.distanceSq(lastMousePosLocal) > DRAGTHRESHOLDSQ) {
+                if (!INVERT_DRAG_MODE) {
                     beginWindowDrag(windowAtOverviewPoint(dragStartMouseLocal));
                 } else if (const auto WORKSPACE = workspaceAtOverviewPoint(dragStartMouseLocal); isWorkspaceScrolling(WORKSPACE)) {
                     beginScrollingPan(WORKSPACE);
@@ -989,8 +973,7 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
         }
 
         if (resizePointerDown && resizePendingWindow) {
-            const float DRAGTHRESHOLD = ScrollOverview::Config::getValue<int>("binds:drag_threshold") * (pMonitor ? pMonitor->m_scale : 1.F);
-            if (!resizeActiveWindow && resizeStartMouseLocal.distanceSq(lastMousePosLocal) > std::pow(DRAGTHRESHOLD, 2))
+            if (!resizeActiveWindow && resizeStartMouseLocal.distanceSq(lastMousePosLocal) > DRAGTHRESHOLDSQ)
                 beginWindowResize();
 
             if (resizeActiveWindow)
@@ -1019,7 +1002,6 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
         if (!dragPendingPrimary && !resizePointerDown && !scrollingPanPointerDown && !dragActiveWindow && !resizeActiveWindow && isPointerOnTopLayer(pMonitor.lock())) {
             submapMouseClickPending = false;
             submapMouseClickButton  = 0;
-            submapMouseClickKeybind.reset();
             return;
         }
 
@@ -1041,20 +1023,32 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
         const auto     clearSubmapMouseClickPending = [&]() {
             submapMouseClickPending = false;
             submapMouseClickButton  = 0;
-            submapMouseClickKeybind.reset();
+        };
+        const auto     beginSubmapMouseClickPending = [&](uint32_t button) {
+            if (!submapActive)
+                return false;
+
+            submapMouseClickPending = true;
+            submapMouseClickButton  = button;
+            dragStartMouseLocal     = lastMousePosLocal;
+            return true;
+        };
+        const auto     shouldRunDefaultClickAction = [&](uint32_t button) {
+            if (submapMouseClickPending && submapMouseClickButton == button) {
+                clearSubmapMouseClickPending();
+                dispatchSubmapMouseClick(button);
+                return false;
+            }
+
+            return !submapActive;
         };
 
         if (event.button == MAIN_BUTTON) {
             lastMousePosLocal = getOverviewMousePosLocal(pMonitor.lock());
 
             if (event.state == WL_POINTER_BUTTON_STATE_PRESSED) {
-                if (const auto KEYBIND = findOverviewSubmapMouseClick(event.button); submapActive && KEYBIND) {
-                    submapMouseClickPending = true;
-                    submapMouseClickButton  = event.button;
-                    submapMouseClickKeybind = KEYBIND;
-                    dragStartMouseLocal     = lastMousePosLocal;
+                if (beginSubmapMouseClickPending(event.button))
                     return;
-                }
 
                 dragPendingPrimary  = true;
                 dragStartMouseLocal = lastMousePosLocal;
@@ -1065,16 +1059,9 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
             if (scrollingPanPointerDown)
                 endScrollingPan();
 
-            const bool  WASPENDINGCLICK         = submapMouseClickPending && submapMouseClickButton == event.button;
-            const auto   PENDINGKEYBIND          = submapMouseClickKeybind;
             const float CLICK_MAX_DRAG_DISTANCE = 10.F * (pMonitor ? pMonitor->m_scale : 1.F);
             const auto   performClickAction      = [&]() {
-                if (WASPENDINGCLICK) {
-                    dispatchSubmapMouseClick(event.button, PENDINGKEYBIND);
-                    return;
-                }
-
-                if (dispatchSubmapMouseClick(event.button))
+                if (!shouldRunDefaultClickAction(event.button))
                     return;
 
                 selectWindowAtOverviewCursor();
@@ -1090,10 +1077,11 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
                     dragOriginalFloatSize = Vector2D{};
                     dragGrabOffsetLocal   = Vector2D{};
                     dragOriginalBox       = CBox{};
-                    clearSubmapMouseClickPending();
 
                     if (!WASPANNING)
                         performClickAction();
+                    else
+                        clearSubmapMouseClickPending();
 
                     return;
                 }
@@ -1104,10 +1092,11 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
             }
 
             clearDragPending();
-            clearSubmapMouseClickPending();
 
             if (!WASPANNING)
                 performClickAction();
+            else
+                clearSubmapMouseClickPending();
             return;
         }
 
@@ -1115,13 +1104,8 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
             lastMousePosLocal = getOverviewMousePosLocal(pMonitor.lock());
 
             if (event.state == WL_POINTER_BUTTON_STATE_PRESSED) {
-                if (const auto KEYBIND = findOverviewSubmapMouseClick(event.button); submapActive && KEYBIND) {
-                    submapMouseClickPending = true;
-                    submapMouseClickButton  = event.button;
-                    submapMouseClickKeybind = KEYBIND;
-                    dragStartMouseLocal     = lastMousePosLocal;
+                if (beginSubmapMouseClickPending(event.button))
                     return;
-                }
 
                 size_t workspaceIdx = 0;
                 const auto WORKSPACE = workspaceAtOverviewCursor(&workspaceIdx);
@@ -1136,16 +1120,13 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
 
             if (submapMouseClickPending && submapMouseClickButton == event.button) {
                 const bool WASPANNING = scrollingPanPointerDown;
-                const auto KEYBIND    = submapMouseClickKeybind;
                 if (scrollingPanPointerDown)
                     endScrollingPan();
 
-                submapMouseClickPending = false;
-                submapMouseClickButton  = 0;
-                submapMouseClickKeybind.reset();
-
                 if (!WASPANNING)
-                    dispatchSubmapMouseClick(event.button, KEYBIND);
+                    shouldRunDefaultClickAction(event.button);
+                else
+                    clearSubmapMouseClickPending();
 
                 return;
             }
@@ -1159,11 +1140,7 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
             lastMousePosLocal = getOverviewMousePosLocal(pMonitor.lock());
 
             if (event.state == WL_POINTER_BUTTON_STATE_PRESSED) {
-                if (const auto KEYBIND = findOverviewSubmapMouseClick(event.button); submapActive && KEYBIND) {
-                    submapMouseClickPending = true;
-                    submapMouseClickButton  = event.button;
-                    submapMouseClickKeybind = KEYBIND;
-                }
+                beginSubmapMouseClickPending(event.button);
 
                 size_t resizeWorkspace = 0;
                 const auto window      = windowAtOverviewCursor(&resizeWorkspace);
@@ -1195,18 +1172,10 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
                 return;
             }
 
-            const bool WASPENDINGCLICK = submapMouseClickPending && submapMouseClickButton == event.button;
-            const auto PENDINGKEYBIND  = submapMouseClickKeybind;
             resizePointerDown = false;
             resizePendingWindow.reset();
 
-            if (WASPENDINGCLICK) {
-                clearSubmapMouseClickPending();
-                dispatchSubmapMouseClick(event.button, PENDINGKEYBIND);
-                return;
-            }
-
-            clearSubmapMouseClickPending();
+            shouldRunDefaultClickAction(event.button);
             return;
         }
 
@@ -1216,6 +1185,9 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
         lastMousePosLocal = getOverviewMousePosLocal(pMonitor.lock());
 
         if (event.state == WL_POINTER_BUTTON_STATE_PRESSED) {
+            if (beginSubmapMouseClickPending(event.button))
+                return;
+
             dragStartMouseLocal = lastMousePosLocal;
             beginWindowDrag(windowAtOverviewCursor());
             return;
@@ -1232,7 +1204,7 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
             dragGrabOffsetLocal   = Vector2D{};
             dragOriginalBox       = CBox{};
 
-            if (dispatchSubmapMouseClick(event.button))
+            if (!shouldRunDefaultClickAction(event.button))
                 return;
 
             selectWindowAtOverviewCursor();
@@ -1247,7 +1219,7 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
 
         clearDragPending();
 
-        if (dispatchSubmapMouseClick(event.button))
+        if (!shouldRunDefaultClickAction(event.button))
             return;
 
         selectWindowAtOverviewCursor();
@@ -4385,7 +4357,6 @@ void CScrollOverview::releaseInputListeners() {
     clearDragPending();
     submapMouseClickPending = false;
     submapMouseClickButton  = 0;
-    submapMouseClickKeybind.reset();
 
     mouseMoveHook.reset();
     touchMoveHook.reset();
@@ -4430,28 +4401,35 @@ void CScrollOverview::restoreSubmapIfActive() {
     submapActive = false;
 }
 
-bool CScrollOverview::dispatchSubmapMouseClick(uint32_t button, const SP<SKeybind>& keybind) {
-    if (!submapActive || !g_pKeybindManager)
+bool CScrollOverview::dispatchSubmapMouseClick(uint32_t button) {
+    if (!submapActive || !g_pKeybindManager || !g_pInputManager)
         return false;
 
-    const auto KEYBIND = keybind ? keybind : findOverviewSubmapMouseClick(button);
-    if (!KEYBIND)
+    const auto KEYNAME = "mouse:" + std::to_string(button);
+    const auto MODS    = g_pInputManager->getModsFromAllKBs();
+
+    const auto KEYBIND = std::ranges::find_if(g_pKeybindManager->m_keybinds, [&](const auto& keybind) {
+        return keybind && keybind->enabled && !keybind->shadowed && keybind->key == KEYNAME && keybind->submap.name == OVERVIEW_SUBMAP &&
+            (keybind->modmask == MODS || keybind->ignoreMods);
+    });
+
+    if (KEYBIND == g_pKeybindManager->m_keybinds.end())
         return false;
 
-    const auto DISPATCHERNAME = KEYBIND->mouse ? "mouse" : KEYBIND->handler;
+    const auto DISPATCHERNAME = (*KEYBIND)->mouse ? "mouse" : (*KEYBIND)->handler;
     const auto DISPATCHER     = g_pKeybindManager->m_dispatchers.find(DISPATCHERNAME);
     if (DISPATCHER == g_pKeybindManager->m_dispatchers.end())
         return false;
 
     const auto PREVIOUSKEYBIND = g_pKeybindManager->m_currentKeybind;
-    g_pKeybindManager->m_currentKeybind = KEYBIND;
+    g_pKeybindManager->m_currentKeybind = *KEYBIND;
     auto restoreKeybind = Hyprutils::Utils::CScopeGuard([PREVIOUSKEYBIND] { g_pKeybindManager->m_currentKeybind = PREVIOUSKEYBIND; });
 
     const int PREVIOUSPASSPRESSED = Config::Actions::state()->m_passPressed;
     Config::Actions::state()->m_passPressed = 0;
     auto restorePassPressed = Hyprutils::Utils::CScopeGuard([PREVIOUSPASSPRESSED] { Config::Actions::state()->m_passPressed = PREVIOUSPASSPRESSED; });
 
-    DISPATCHER->second(KEYBIND->mouse ? "0" + KEYBIND->arg : KEYBIND->arg);
+    DISPATCHER->second((*KEYBIND)->mouse ? "0" + (*KEYBIND)->arg : (*KEYBIND)->arg);
     return true;
 }
 

--- a/scrollOverview.hpp
+++ b/scrollOverview.hpp
@@ -12,6 +12,7 @@
 #include <hyprland/src/render/Framebuffer.hpp>
 #include <hyprland/src/render/types.hpp>
 #include <chrono>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -19,6 +20,7 @@
 #include "IOverview.hpp"
 
 class CMonitor;
+struct SKeybind;
 struct wl_event_source;
 
 class CScrollOverview : public IOverview {
@@ -46,6 +48,8 @@ class CScrollOverview : public IOverview {
     // close without a selection
     void         close() override;
     void         selectHoveredWorkspace() override;
+    bool         moveSelection(const std::string& direction) override;
+    bool         windowDispatcherAction(const std::string& action) override;
 
     void         fullRender() override;
 
@@ -69,7 +73,8 @@ class CScrollOverview : public IOverview {
     void   trackpadSwipeWorkspace(const double delta);
     void   finishWorkspaceScrollFollow(float logicalPitch);
     bool   scrollStepAllowed(uint32_t timeMs);
-    bool   moveWindowSelection(const std::string& direction);
+    bool   selectOverviewWindow(PHLWINDOW window, size_t workspaceIdx, bool syncFocus = false);
+    bool   selectWindowAtOverviewCursor(bool syncFocus = false);
     void   rememberSelection(PHLWINDOW window);
     void   syncSelectionToViewport();
     void   syncFocusedSelection();
@@ -121,6 +126,9 @@ class CScrollOverview : public IOverview {
     void   schedulePreviewFrameAfter(std::chrono::milliseconds delay);
     void   scheduleRealtimePreviewFrame();
     void   releaseInputListeners();
+    void   activateSubmapIfConfigured();
+    void   restoreSubmapIfActive();
+    bool   dispatchSubmapMouseClick(uint32_t button, const SP<SKeybind>& keybind = {});
     void   requestInputFrame();
     static int realtimePreviewTimerCallback(void* data);
 
@@ -171,11 +179,13 @@ class CScrollOverview : public IOverview {
     Vector2D                         scrollingPanLastMouseLocal = Vector2D{};
     CBox                             dragOriginalBox        = CBox{};
     CBox                             resizeOriginalBox      = CBox{};
+    WORKSPACEID                      focusSyncedFromWorkspaceID = WORKSPACE_INVALID;
     size_t                           resizeWorkspaceIdx     = 0;
     Layout::eRectCorner              resizeCorner           = Layout::CORNER_NONE;
     bool                             dragPendingPrimary    = false;
     bool                             resizePointerDown     = false;
     bool                             scrollingPanPointerDown = false;
+    bool                             submapMouseClickPending = false;
     bool                             dragStartedTiled      = false;
     bool                             emittingFullscreenVisibilityState = false;
     bool                             inputConfigOverridden = false;
@@ -183,6 +193,11 @@ class CScrollOverview : public IOverview {
     bool                             realtimePreviewFrameQueued = false;
     bool                             inputFramePending = false;
     bool                             sendingOverviewFrameCallbacks = false;
+    bool                             usesSubmapKeybinds = false;
+    bool                             submapActive = false;
+    uint32_t                         submapMouseClickButton = 0;
+    SP<SKeybind>                     submapMouseClickKeybind;
+    std::string                      previousSubmapName;
     int                              previousNoWarps = 0;
     int                              previousWarpOnChangeWorkspace = 0;
     int                              previousWarpOnToggleSpecial = 0;

--- a/scrollOverview.hpp
+++ b/scrollOverview.hpp
@@ -20,7 +20,6 @@
 #include "IOverview.hpp"
 
 class CMonitor;
-struct SKeybind;
 struct wl_event_source;
 
 class CScrollOverview : public IOverview {
@@ -128,7 +127,7 @@ class CScrollOverview : public IOverview {
     void   releaseInputListeners();
     void   activateSubmapIfConfigured();
     void   restoreSubmapIfActive();
-    bool   dispatchSubmapMouseClick(uint32_t button, const SP<SKeybind>& keybind = {});
+    bool   dispatchSubmapMouseClick(uint32_t button);
     void   requestInputFrame();
     static int realtimePreviewTimerCallback(void* data);
 
@@ -196,7 +195,6 @@ class CScrollOverview : public IOverview {
     bool                             usesSubmapKeybinds = false;
     bool                             submapActive = false;
     uint32_t                         submapMouseClickButton = 0;
-    SP<SKeybind>                     submapMouseClickKeybind;
     std::string                      previousSubmapName;
     int                              previousNoWarps = 0;
     int                              previousWarpOnChangeWorkspace = 0;


### PR DESCRIPTION
This PR implements keybind submaps, which allows much greater customization. If no "scrolloverview" submap is registered, it defaults to the built-in navigation.

### Added dispatchers:

#### `scrolloverview:navigate`

Moves the overview selection/focus between windows in the current workspace. If
there are no more windows in that direction, it selects the next workspace when
the direction matches the configured overview layout.

| option | description |
| --- | --- |
| `left` | move selection left |
| `right` | move selection right |
| `up` | move selection up |
| `down` | move selection down |

#### `scrolloverview:window`

Acts on an overview window. Mouse binds use the window under the cursor;
keyboard binds use the currently selected window.

| option | description |
| --- | --- |
| `select` | focus/select the window under the mouse cursor |
| `close` | close the window under the mouse cursor |

<br>
<br>

### Submap example:

```lua
-- hyprland.lua
hl.define_submap("scrolloverview", function()
    hl.bind("left",   hl.plugin.scrolloverview.navigate("left"))
    hl.bind("right",  hl.plugin.scrolloverview.navigate("right"))
    hl.bind("up",     hl.plugin.scrolloverview.navigate("up"))
    hl.bind("down",   hl.plugin.scrolloverview.navigate("down"))
    hl.bind("return", hl.plugin.scrolloverview.overview("off"))
    hl.bind("escape", hl.plugin.scrolloverview.overview("off"))
    hl.bind("mouse:272", function()
        hl.plugin.scrolloverview.window("select")
        hl.plugin.scrolloverview.overview("select")
        hl.plugin.scrolloverview.overview("off")
    end, { mouse = true })
    hl.bind("mouse:274", hl.plugin.scrolloverview.window("close"), { mouse = true })
end)

-- Example Hyprland bind that keeps working inside the submap:
for i = 1, 10 do
    local key = i % 10
    hl.bind("ALT + " .. key, hl.dsp.focus({ workspace = i }), { submap_universal = true })
end
```