### PR TITLE
Touchpad scroll improvements

### DIFF
--- a/Config.cpp
+++ b/Config.cpp
@@ -273,6 +273,9 @@ static void registerConfigValues() {
     HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE,
                                   makeShared<CIntValue>("plugin:scrolloverview:input:scroll_event_delay", "minimum delay (ms) between discrete scroll steps (wheel workspace nav and trackpad focus stepping)", 200, SIntValueOptions{.min = 0}));
     HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE,
+                                  makeShared<CFloatValue>("plugin:scrolloverview:input:touchpad_scroll_factor", "overview touchpad scroll factor", 1.F,
+                                                          SFloatValueOptions{.min = 0.F}));
+    HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE,
                                   makeShared<CIntValue>("plugin:scrolloverview:input:left_handed", "overview left handed mouse buttons, 2 follows input:left_handed", 2,
                                                         SIntValueOptions{.min = 0, .max = 2}));
     HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE,
@@ -334,6 +337,13 @@ int getDragMode() {
 
 int getDragThreshold() {
     return std::max<int>(0, getValue<int>("plugin:scrolloverview:input:drag_threshold"));
+}
+
+float getTouchpadScrollFactor() {
+    static constexpr float OVERVIEWTOUCHPADSCROLLFACTOR = 1.5F;
+
+    return OVERVIEWTOUCHPADSCROLLFACTOR * std::max<float>(0.F, getValue<float>("input:touchpad:scroll_factor")) *
+        std::max<float>(0.F, getValue<float>("plugin:scrolloverview:input:touchpad_scroll_factor"));
 }
 
 static EScrollAction defaultVerticalScrollAction(ELayout layout) {

--- a/Config.hpp
+++ b/Config.hpp
@@ -83,6 +83,7 @@ int           getScrollEventDelay();
 bool          getLeftHanded();
 int           getDragMode();
 int           getDragThreshold();
+float         getTouchpadScrollFactor();
 EScrollAction getVerticalScrollAction(ELayout layout);
 EScrollAction getHorizontalScrollAction(ELayout layout);
 int           getWallpaperMode();

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ In Lua, `shadow.color` must be an integer color value. The Hyprlang-only
 | --- | --- | --- | --- |
 | left_handed | int | swap left and right mouse button actions in overview: `0` disabled, `1` enabled | `input:left_handed` |
 | scroll_event_delay | number | in ms, delay between scroll events (to prevent multiple activation) | `200` |
+| touchpad_scroll_factor | float | overview touchpad workspace scroll distance multiplier | `1` |
 | scrolling_mode | int | mouse wheel behavior: `0` layout-aware default, `1` inverted, `2` vertical scroll changes workspace and horizontal scroll changes columns, `3` vertical scroll changes columns and horizontal scroll changes workspace | `0` |
 | drag_mode | int | mouse drag behavior: `0` main button drags windows and middle button pans scrolling workspaces, `1` main button pans scrolling workspaces and middle button drags windows | `0` |
 | drag_threshold | int | movement threshold in pixels before a mouse press becomes drag/pan/resize instead of click; `0` disables the threshold | `10` |

--- a/scrollOverview.cpp
+++ b/scrollOverview.cpp
@@ -1261,12 +1261,6 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
         if (closing)
             return;
 
-        const auto MODS = g_pInputManager->getModsFromAllKBs() &
-                          (HL_MODIFIER_SHIFT | HL_MODIFIER_META | HL_MODIFIER_CTRL | HL_MODIFIER_ALT);
-
-        if (MODS != 0)
-            return;
-
         info.cancelled = true;
 
         const auto ACTION = e.axis == WL_POINTER_AXIS_HORIZONTAL_SCROLL ? ScrollOverview::Config::getHorizontalScrollAction(layout) :
@@ -2965,7 +2959,7 @@ void CScrollOverview::trackpadSwipeLayout(const PHLWORKSPACE target, const doubl
     }
 
     trackpadTapeFollowing = true;
-    ALGO->moveTape(sc<float>(-1 * delta / SCALE));
+    ALGO->moveTape(sc<float>(-1 * delta * ScrollOverview::Config::getTouchpadScrollFactor() / SCALE));
     damage();
 }
 
@@ -2974,52 +2968,94 @@ void CScrollOverview::trackpadSwipeWorkspace(const double delta) {
     if (!MONITOR)
         return;
 
-    const float SCALE = std::max<float>(scale->value(), 0.01F);
-    const float PITCH = getWorkspaceLogicalPitch(MONITOR, SCALE, layout);
-
     // fingers lifted — snap to the nearest workspace
     if (delta == 0.0) {
-        finishWorkspaceScrollFollow(PITCH);
+        finishWorkspaceScrollFollow();
         return;
     }
 
+    const float SCALE = std::max<float>(scale->value(), 0.01F);
+
     trackpadWorkspaceFollowing  = true;
-    trackpadScrollAccum         += delta;
+    trackpadScrollAccum         += delta * ScrollOverview::Config::getTouchpadScrollFactor();
 
-    double offset = trackpadScrollAccum / SCALE;
-
-    // clamp so the view can't be dragged past the first / last workspace
-    const double curIdx  = sc<double>(viewportCurrentWorkspace);
-    const double maxNext = (sc<double>(images.size()) - 1.0 - curIdx) * PITCH;
-    const double maxPrev = -curIdx * PITCH;
-    offset               = std::clamp(offset, maxPrev, maxNext);
-    trackpadScrollAccum  = offset * SCALE;
-
-    viewOffset->setValueAndWarp(axisOffsetVector(sc<float>(offset), layout));
+    viewOffset->setValueAndWarp(axisOffsetVector(sc<float>(trackpadWorkspaceScrollOffset(MONITOR, SCALE)), layout));
     damage();
 }
 
-void CScrollOverview::finishWorkspaceScrollFollow(float logicalPitch) {
+double CScrollOverview::trackpadWorkspaceScrollOffset(PHLMONITOR monitor, float renderScale) {
+    const float RENDEREDLOGICALUNIT = renderScale * std::max<float>(monitor->m_scale, 0.01F);
+    const float LOGICALPITCH        = getWorkspaceLogicalPitch(monitor, renderScale, layout);
+
+    double offset    = trackpadScrollAccum / RENDEREDLOGICALUNIT;
+    double minOffset = 0.0;
+    double maxOffset = 0.0;
+
+    for (size_t i = 0; i < images.size(); ++i) {
+        if (!images[i] || !images[i]->pWorkspace)
+            continue;
+
+        const double WORKSPACEOFFSET = workspaceOverviewLogicalOffset(i, viewportCurrentWorkspace, LOGICALPITCH);
+        minOffset                    = std::min(minOffset, WORKSPACEOFFSET);
+        maxOffset                    = std::max(maxOffset, WORKSPACEOFFSET);
+    }
+
+    offset              = std::clamp(offset, minOffset, maxOffset);
+    trackpadScrollAccum = offset * RENDEREDLOGICALUNIT;
+
+    return offset;
+}
+
+void CScrollOverview::finishWorkspaceScrollFollow() {
     if (!trackpadWorkspaceFollowing)
         return;
+
+    const auto MONITOR = pMonitor.lock();
+    if (!MONITOR) {
+        trackpadWorkspaceFollowing = false;
+        trackpadScrollAccum        = 0.0;
+        return;
+    }
 
     trackpadWorkspaceFollowing  = false;
     trackpadScrollAccum         = 0.0;
 
-    const double OFFSET = axisValue(viewOffset->value(), layout);
-    const long   STEPS  = std::lround(OFFSET / logicalPitch);
+    const float  SCALE          = std::max<float>(scale->value(), 0.01F);
+    const float  LOGICALPITCH   = getWorkspaceLogicalPitch(MONITOR, SCALE, layout);
+    const float  RENDEREDPITCH  = getWorkspaceRenderedPitch(MONITOR, SCALE, layout);
+    const size_t ACTIVEIDX      = activeWorkspaceIndex();
+    const double VIEWPORTCENTER = axisSize(MONITOR->m_size * MONITOR->m_scale, layout) / 2.0;
 
-    if (STEPS == 0) {
+    size_t targetIdx    = viewportCurrentWorkspace;
+    double bestDistance = std::numeric_limits<double>::max();
+
+    for (size_t i = 0; i < images.size(); ++i) {
+        if (!images[i] || !images[i]->pWorkspace)
+            continue;
+
+        const auto   WORKSPACEBOX = getOverviewWorkspaceBox(MONITOR, SCALE, viewOffset->value(), workspaceOverviewOffset(i, ACTIVEIDX, RENDEREDPITCH), layout);
+        const double DISTANCE     = std::abs(axisValue(WORKSPACEBOX.middle(), layout) - VIEWPORTCENTER);
+        if (DISTANCE < bestDistance) {
+            bestDistance = DISTANCE;
+            targetIdx    = i;
+        }
+    }
+
+    if (targetIdx == viewportCurrentWorkspace) {
         *viewOffset = Vector2D{};
         return;
     }
 
-    trackpadGestureSettleOffset  = OFFSET - sc<double>(STEPS) * logicalPitch;
+    const double OFFSET       = axisValue(viewOffset->value(), layout);
+    const double TARGETOFFSET = workspaceOverviewLogicalOffset(targetIdx, viewportCurrentWorkspace, LOGICALPITCH);
+
+    trackpadGestureSettleOffset  = OFFSET - TARGETOFFSET;
     trackpadGestureSettlePending = true;
 
     const size_t BEFORE = viewportCurrentWorkspace;
-    const bool   NEXT   = STEPS > 0;
-    for (long i = 0; i < std::abs(STEPS); ++i)
+    const bool   NEXT   = targetIdx > viewportCurrentWorkspace;
+    const size_t STEPS  = sc<size_t>(std::abs(sc<long>(targetIdx) - sc<long>(viewportCurrentWorkspace)));
+    for (size_t i = 0; i < STEPS; ++i)
         moveViewportWorkspace(NEXT);
 
     if (viewportCurrentWorkspace == BEFORE) {

--- a/scrollOverview.hpp
+++ b/scrollOverview.hpp
@@ -72,7 +72,8 @@ class CScrollOverview : public IOverview {
     void   moveViewportWorkspace(bool up);
     void   trackpadSwipeLayout(const PHLWORKSPACE target, const double delta);
     void   trackpadSwipeWorkspace(const double delta);
-    void   finishWorkspaceScrollFollow(float logicalPitch);
+    void   finishWorkspaceScrollFollow();
+    double trackpadWorkspaceScrollOffset(PHLMONITOR monitor, float renderScale);
     bool   scrollStepAllowed(uint32_t timeMs);
     bool   selectOverviewWindow(PHLWINDOW window, size_t workspaceIdx, bool syncFocus = false);
     bool   selectWindowAtOverviewCursor(bool syncFocus = false);


### PR DESCRIPTION
- Removes scale factor during workspace scroll (it is now possible to scroll through multiple workspaces in a single scroll event)
- Snaps to the nearest workspace at the end of the scroll event
- Adds scrolloverview.input.touchpad_scroll_factor to fine-tune scroll sensitivity
- Changes default scroll factor to something more sensible (needs more testing)
- Removes modifier-key guards during scroll events, so it possible to use modifiers to change scroll direction (in Lua config), examples will be added to the wiki once I finish working on it.

Closes #40