### PR TITLE
Drop indicator

### DIFF
--- a/Config.cpp
+++ b/Config.cpp
@@ -369,16 +369,15 @@ bool getBlur() {
 }
 
 ::Config::CCssGapData getCssGapData(const std::string& name) {
-    const auto VALUE = HyprlandAPI::getConfigValue(SCROLLOVERVIEW_HANDLE, name);
-    if (!VALUE)
+    auto& VALUE = valueRef<::Config::IComplexConfigValue>(name);
+    if (!VALUE.good())
         return {};
 
-    const auto CUSTOM = rc<Hyprlang::CUSTOMTYPE* const*>(VALUE->getDataStaticPtr());
-    if (!CUSTOM || !*CUSTOM)
+    auto* const GAPS = dc<::Config::CCssGapData*>(VALUE.ptr());
+    if (!GAPS)
         return {};
 
-    const auto* const GAPS = sc<::Config::CCssGapData*>((*CUSTOM)->getData());
-    return GAPS ? *GAPS : ::Config::CCssGapData{};
+    return *GAPS;
 }
 
 int getShadowEnabled() {

--- a/DropIndicator.cpp
+++ b/DropIndicator.cpp
@@ -14,7 +14,7 @@
 
 namespace {
 
-static constexpr float INDICATOR_SIZE_PX = 150.F;
+static constexpr float INDICATOR_BASE_SIZE_PX = 200.F;
 static constexpr float INDICATOR_ALPHA   = 0.3F;
 
 static CHyprColor indicatorColor() {
@@ -55,7 +55,7 @@ static CBox scrollingIndicatorBox(const CDropIndicator::SRenderParams& params) {
     const bool  HORIZONTALSIDE = isHorizontalSide(params.anchor.direction);
     const bool  PRIMARYHORIZONTAL = scrollingPrimaryHorizontal(params.workspace);
     const float MONITOR_SCALE = std::max<float>(params.monitor ? params.monitor->m_scale : 1.F, 0.01F);
-    const float SIZE = INDICATOR_SIZE_PX * MONITOR_SCALE;
+    const float SIZE = INDICATOR_BASE_SIZE_PX * std::max(params.renderScale, 0.01F) * MONITOR_SCALE;
     const auto& EDGEBOX = params.anchor.logicalBox.empty() ? params.anchor.box : params.anchor.logicalBox;
     CBox        box;
 

--- a/DropIndicator.cpp
+++ b/DropIndicator.cpp
@@ -1,0 +1,146 @@
+#include "DropIndicator.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <sstream>
+
+#define private public
+#include <hyprland/src/desktop/view/Window.hpp>
+#include <hyprland/src/layout/algorithm/Algorithm.hpp>
+#include <hyprland/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.hpp>
+#include <hyprland/src/render/Renderer.hpp>
+#include <hyprland/src/render/pass/RectPassElement.hpp>
+#undef private
+
+namespace {
+
+static constexpr float INDICATOR_SIZE_PX = 150.F;
+static constexpr float INDICATOR_ALPHA   = 0.3F;
+
+static CHyprColor indicatorColor() {
+    auto* const ACTIVEBORDER = sc<Config::CGradientValueData*>(ScrollOverview::Config::valueRef<Config::IComplexConfigValue>("general:col.active_border").ptr());
+    if (!ACTIVEBORDER || ACTIVEBORDER->m_colors.empty())
+        return Colors::WHITE.modifyA(INDICATOR_ALPHA);
+
+    return ACTIVEBORDER->m_colors[0].modifyA(INDICATOR_ALPHA);
+}
+
+static bool isHorizontalSide(const std::string& side) {
+    return side == "l" || side == "r";
+}
+
+static bool isVerticalSide(const std::string& side) {
+    return side == "u" || side == "d";
+}
+
+static Layout::Tiled::CScrollingAlgorithm* scrollingAlgorithmForWorkspace(const PHLWORKSPACE& workspace) {
+    if (!workspace || !workspace->m_space || !workspace->m_space->algorithm())
+        return nullptr;
+
+    return dc<Layout::Tiled::CScrollingAlgorithm*>(workspace->m_space->algorithm()->m_tiled.get());
+}
+
+static bool scrollingPrimaryHorizontal(const PHLWORKSPACE& workspace) {
+    const auto ALGO = scrollingAlgorithmForWorkspace(workspace);
+    if (!ALGO || !ALGO->m_scrollingData || !ALGO->m_scrollingData->controller)
+        return true;
+
+    return ALGO->m_scrollingData->controller->isPrimaryHorizontal();
+}
+
+static CBox scrollingIndicatorBox(const CDropIndicator::SRenderParams& params) {
+    if (!params.anchor.window)
+        return params.workspaceUsableBox;
+
+    const bool  HORIZONTALSIDE = isHorizontalSide(params.anchor.direction);
+    const bool  PRIMARYHORIZONTAL = scrollingPrimaryHorizontal(params.workspace);
+    const float MONITOR_SCALE = std::max<float>(params.monitor ? params.monitor->m_scale : 1.F, 0.01F);
+    const float SIZE = INDICATOR_SIZE_PX * MONITOR_SCALE;
+    const auto& EDGEBOX = params.anchor.logicalBox.empty() ? params.anchor.box : params.anchor.logicalBox;
+    CBox        box;
+
+    if (HORIZONTALSIDE) {
+        const float CENTERX = params.anchor.direction == "l" ? EDGEBOX.x : EDGEBOX.x + EDGEBOX.width;
+        box.width  = SIZE;
+        box.height = PRIMARYHORIZONTAL ? params.workspaceUsableBox.height : params.anchor.box.height;
+        box.x      = CENTERX - SIZE / 2.F;
+        box.y      = PRIMARYHORIZONTAL ? params.workspaceUsableBox.y : params.anchor.box.y;
+    } else {
+        const float CENTERY = params.anchor.direction == "u" ? EDGEBOX.y : EDGEBOX.y + EDGEBOX.height;
+        box.width  = PRIMARYHORIZONTAL ? params.anchor.box.width : params.workspaceUsableBox.width;
+        box.height = SIZE;
+        box.x      = PRIMARYHORIZONTAL ? params.anchor.box.x : params.workspaceUsableBox.x;
+        box.y      = CENTERY - SIZE / 2.F;
+    }
+
+    box.round();
+    return box;
+}
+
+static CBox indicatorBox(const CDropIndicator::SRenderParams& params) {
+    if (!params.anchor.window)
+        return params.workspaceUsableBox;
+
+    if (params.anchor.direction.empty())
+        return params.anchor.box;
+
+    if (!scrollingAlgorithmForWorkspace(params.workspace))
+        return params.anchor.box;
+
+    return scrollingIndicatorBox(params);
+}
+
+static CBox clipScrollingIndicatorBox(CBox box, const CDropIndicator::SRenderParams& params) {
+    if (!scrollingAlgorithmForWorkspace(params.workspace))
+        return box;
+
+    const bool OVERVIEWLAYOUTHORIZONTAL = params.layout == ScrollOverview::Config::ELayout::HORIZONTAL;
+    const bool PRIMARYHORIZONTAL        = scrollingPrimaryHorizontal(params.workspace);
+
+    if (PRIMARYHORIZONTAL && !OVERVIEWLAYOUTHORIZONTAL)
+        return box.intersection({{box.x, params.workspaceUsableBox.y}, {box.width, params.workspaceUsableBox.height}});
+
+    if (!PRIMARYHORIZONTAL && OVERVIEWLAYOUTHORIZONTAL)
+        return box.intersection({{params.workspaceUsableBox.x, box.y}, {params.workspaceUsableBox.width, box.height}});
+
+    return box;
+}
+
+static int indicatorRounding(const CDropIndicator::SRenderParams& params) {
+    const float ROUNDING = params.anchor.window ? params.anchor.window->rounding() : ScrollOverview::Config::getValue<int>("decoration:rounding");
+    const float SCALE    = std::max(params.renderScale, 0.01F) * std::max<float>(params.monitor ? params.monitor->m_scale : 1.F, 0.01F);
+
+    return std::max(0, sc<int>(std::round(ROUNDING * SCALE)));
+}
+
+static float indicatorRoundingPower(const CDropIndicator::SRenderParams& params) {
+    if (params.anchor.window)
+        return params.anchor.window->roundingPower();
+
+    return ScrollOverview::Config::getValue<float>("decoration:rounding_power");
+}
+
+}
+
+void CDropIndicator::renderDropIndicator(const SRenderParams& params) {
+    if (!params.monitor || !params.workspace)
+        return;
+
+    if (params.workspaceFullyVisible && !params.anchor.window)
+        return;
+
+    if (params.anchor.window && !params.anchor.direction.empty() && !isHorizontalSide(params.anchor.direction) && !isVerticalSide(params.anchor.direction))
+        return;
+
+    const auto BOX = clipScrollingIndicatorBox(indicatorBox(params), params);
+    if (BOX.empty())
+        return;
+
+    CRectPassElement::SRectData data;
+    data.box           = BOX;
+    data.color         = indicatorColor();
+    data.round         = indicatorRounding(params);
+    data.roundingPower = indicatorRoundingPower(params);
+
+    g_pHyprRenderer->m_renderPass.add(makeUnique<CRectPassElement>(data));
+}

--- a/DropIndicator.cpp
+++ b/DropIndicator.cpp
@@ -94,16 +94,12 @@ static CBox clipScrollingIndicatorBox(CBox box, const CDropIndicator::SRenderPar
     if (!scrollingAlgorithmForWorkspace(params.workspace))
         return box;
 
-    const bool OVERVIEWLAYOUTHORIZONTAL = params.layout == ScrollOverview::Config::ELayout::HORIZONTAL;
-    const bool PRIMARYHORIZONTAL        = scrollingPrimaryHorizontal(params.workspace);
+    const bool PRIMARYHORIZONTAL = scrollingPrimaryHorizontal(params.workspace);
 
-    if (PRIMARYHORIZONTAL && !OVERVIEWLAYOUTHORIZONTAL)
+    if (PRIMARYHORIZONTAL)
         return box.intersection({{box.x, params.workspaceUsableBox.y}, {box.width, params.workspaceUsableBox.height}});
 
-    if (!PRIMARYHORIZONTAL && OVERVIEWLAYOUTHORIZONTAL)
-        return box.intersection({{params.workspaceUsableBox.x, box.y}, {params.workspaceUsableBox.width, box.height}});
-
-    return box;
+    return box.intersection({{params.workspaceUsableBox.x, box.y}, {params.workspaceUsableBox.width, box.height}});
 }
 
 static int indicatorRounding(const CDropIndicator::SRenderParams& params) {

--- a/DropIndicator.hpp
+++ b/DropIndicator.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "Config.hpp"
+#include "globals.hpp"
+
+#include <string>
+
+class CDropIndicator {
+  public:
+    struct SDropAnchor {
+        PHLWINDOW   window;
+        CBox        box;
+        CBox        logicalBox;
+        std::string direction;
+    };
+
+    struct SRenderParams {
+        PHLMONITOR   monitor;
+        PHLWORKSPACE workspace;
+        CBox         workspaceUsableBox;
+        SDropAnchor  anchor;
+        float        renderScale = 1.F;
+        bool         workspaceFullyVisible = false;
+        ScrollOverview::Config::ELayout layout = ScrollOverview::Config::ELayout::VERTICAL;
+    };
+
+    static void renderDropIndicator(const SRenderParams& params);
+};

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,6 @@ ifeq ($(CXX),g++)
 endif
 
 all:
-	$(CXX) -shared -fPIC $(EXTRA_FLAGS) main.cpp Config.cpp OverviewGesture.cpp OverviewPassElement.cpp OverviewRender.cpp Window.cpp scrollOverview.cpp -o scrolloverview.so -g `pkg-config --cflags pixman-1 libdrm hyprland pangocairo libinput libudev wayland-server xkbcommon lua5.4` -std=c++2b -Wno-narrowing
+	$(CXX) -shared -fPIC $(EXTRA_FLAGS) main.cpp Config.cpp DropIndicator.cpp OverviewGesture.cpp OverviewPassElement.cpp OverviewRender.cpp Window.cpp scrollOverview.cpp -o scrolloverview.so -g `pkg-config --cflags pixman-1 libdrm hyprland pangocairo libinput libudev wayland-server xkbcommon lua5.4` -std=c++2b -Wno-narrowing
 clean:
 	rm ./scrolloverview.so

--- a/scrollOverview.cpp
+++ b/scrollOverview.cpp
@@ -56,6 +56,7 @@
 #undef protected
 #undef private
 #include "Config.hpp"
+#include "DropIndicator.hpp"
 #include "OverviewPassElement.hpp"
 #include "OverviewRender.hpp"
 #include "Window.hpp"
@@ -224,15 +225,27 @@ static bool layerHasOverviewAnimation(const PHLLS& layer) {
 
 static Vector2D axisOffsetVector(float offset, ScrollOverview::Config::ELayout layout);
 
-static CBox getOverviewWindowBox(const PHLWINDOW& window, PHLMONITOR monitor, float scale, const Vector2D& viewOffset, float offset, ScrollOverview::Config::ELayout layout) {
+static CBox getOverviewBox(CBox box, PHLMONITOR monitor, float scale, const Vector2D& viewOffset, float offset, ScrollOverview::Config::ELayout layout,
+                           bool round = true) {
     const auto MONITORSCALE    = monitor->m_scale;
     const auto VIEWPORT_CENTER = CBox{{}, monitor->m_size * MONITORSCALE}.middle();
 
-    CBox       box            = {(window->m_realPosition->value() - monitor->m_position) * MONITORSCALE, window->m_realSize->value() * MONITORSCALE};
+    box = {box.pos() * MONITORSCALE, box.size() * MONITORSCALE};
     box.translate(-VIEWPORT_CENTER).scale(scale).translate(VIEWPORT_CENTER).translate(-viewOffset * scale * MONITORSCALE).translate(axisOffsetVector(offset, layout));
-    box.round();
+    if (round)
+        box.round();
 
     return box;
+}
+
+static CBox getOverviewGlobalBox(CBox globalBox, PHLMONITOR monitor, float scale, const Vector2D& viewOffset, float offset, ScrollOverview::Config::ELayout layout,
+                                 bool round = true) {
+    return getOverviewBox({globalBox.pos() - monitor->m_position, globalBox.size()}, monitor, scale, viewOffset, offset, layout, round);
+}
+
+static CBox getOverviewWindowBox(const PHLWINDOW& window, PHLMONITOR monitor, float scale, const Vector2D& viewOffset, float offset, ScrollOverview::Config::ELayout layout,
+                                 bool round = true) {
+    return getOverviewGlobalBox({window->m_realPosition->value(), window->m_realSize->value()}, monitor, scale, viewOffset, offset, layout, round);
 }
 
 static CBox expandOverviewWindowHitbox(CBox box, float scale, float monitorScale) {
@@ -275,14 +288,7 @@ static float axisSize(const Vector2D& size, ScrollOverview::Config::ELayout layo
 }
 
 static CBox getOverviewWorkspaceBox(PHLMONITOR monitor, float scale, const Vector2D& viewOffset, float offset, ScrollOverview::Config::ELayout layout) {
-    const auto MONITORSCALE    = monitor->m_scale;
-    const auto VIEWPORT_CENTER = CBox{{}, monitor->m_size * MONITORSCALE}.middle();
-
-    CBox       box            = {{}, monitor->m_size * MONITORSCALE};
-    box.translate(-VIEWPORT_CENTER).scale(scale).translate(VIEWPORT_CENTER).translate(-viewOffset * scale * MONITORSCALE).translate(axisOffsetVector(offset, layout));
-    box.round();
-
-    return box;
+    return getOverviewBox({{}, monitor->m_size}, monitor, scale, viewOffset, offset, layout);
 }
 
 static CBox getWorkspaceGlobalBox(PHLWORKSPACE workspace, PHLMONITOR fallbackMonitor) {
@@ -426,6 +432,14 @@ static bool overviewBoxIntersectsMonitor(const CBox& box, PHLMONITOR monitor) {
     const auto RENDERSIZE = monitor->m_size * monitor->m_scale;
 
     return box.x < RENDERSIZE.x && box.x + box.width > 0 && box.y < RENDERSIZE.y && box.y + box.height > 0;
+}
+
+static bool overviewBoxFullyVisibleOnMonitor(const CBox& box, PHLMONITOR monitor) {
+    if (!monitor || box.empty())
+        return false;
+
+    const CBox VIEWPORT = {{}, monitor->m_size * monitor->m_scale};
+    return box.x >= VIEWPORT.x && box.y >= VIEWPORT.y && box.x + box.width <= VIEWPORT.x + VIEWPORT.width && box.y + box.height <= VIEWPORT.y + VIEWPORT.height;
 }
 
 static double overviewBoxIntersectionArea(const CBox& a, const CBox& b) {
@@ -663,6 +677,27 @@ static bool isWorkspaceScrolling(const PHLWORKSPACE& workspace) {
     return overviewScrollingAlgorithmForWorkspace(workspace) != nullptr;
 }
 
+static CBox getOverviewWorkspaceUsableBox(const PHLWORKSPACE& workspace, PHLMONITOR monitor, float scale, const Vector2D& viewOffset, float offset,
+                                          ScrollOverview::Config::ELayout layout) {
+    if (!workspace || !monitor)
+        return {};
+
+    if (const auto ALGO = overviewScrollingAlgorithmForWorkspace(workspace); ALGO && ALGO->m_scrollingData && ALGO->m_scrollingData->controller) {
+        const auto USABLE = ALGO->usableArea();
+        return getOverviewBox(USABLE, monitor, scale, viewOffset, offset, layout);
+    }
+
+    if (!workspace->m_space)
+        return getOverviewWorkspaceBox(monitor, scale, viewOffset, offset, layout);
+
+    auto USABLE = workspace->m_space->workArea();
+    USABLE.translate(-monitor->m_position);
+    USABLE.w = std::max(USABLE.w, 1.0);
+    USABLE.h = std::max(USABLE.h, 1.0);
+
+    return getOverviewBox(USABLE, monitor, scale, viewOffset, offset, layout);
+}
+
 static double clampOverviewScrollingOffset(Layout::Tiled::CScrollingAlgorithm* algo, double offset) {
     if (!algo || !algo->m_scrollingData)
         return offset;
@@ -892,6 +927,23 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
 
         lastMousePosLocal = getOverviewMousePosLocal(pMonitor.lock());
 
+        const auto beginScrollingPanAtPoint = [&](const Vector2D& point) {
+            auto WORKSPACE = workspaceAtOverviewPoint(point);
+            if (!WORKSPACE) {
+                const auto WINDOW = windowAtOverviewPoint(point);
+                if (WINDOW)
+                    WORKSPACE = WINDOW->m_workspace;
+            }
+
+            if (!isWorkspaceScrolling(WORKSPACE))
+                return false;
+
+            beginScrollingPan(WORKSPACE);
+            scrollingPanLastMouseLocal = point;
+            updateScrollingPan();
+            return true;
+        };
+
         if (!dragPendingPrimary && !resizePointerDown && !scrollingPanPointerDown && !dragActiveWindow && !resizeActiveWindow && isPointerOnTopLayer(pMonitor.lock())) {
             submapMouseClickPending = false;
             submapMouseClickButton  = 0;
@@ -910,20 +962,14 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
 
                 if (!INVERT_DRAG_MODE)
                     beginWindowDrag(windowAtOverviewPoint(dragStartMouseLocal));
-                else if (const auto WORKSPACE = workspaceAtOverviewPoint(dragStartMouseLocal); isWorkspaceScrolling(WORKSPACE)) {
-                    beginScrollingPan(WORKSPACE);
-                    scrollingPanLastMouseLocal = dragStartMouseLocal;
-                    updateScrollingPan();
-                }
+                else
+                    beginScrollingPanAtPoint(dragStartMouseLocal);
             }
 
             if (submapMouseClickButton == SECONDARY_DRAG_BUTTON && !INVERT_DRAG_MODE && !scrollingPanPointerDown && DRAGTHRESHOLDREACHED) {
-                if (const auto WORKSPACE = workspaceAtOverviewPoint(dragStartMouseLocal); isWorkspaceScrolling(WORKSPACE)) {
+                if (beginScrollingPanAtPoint(dragStartMouseLocal)) {
                     submapMouseClickPending = false;
                     submapMouseClickButton  = 0;
-                    beginScrollingPan(WORKSPACE);
-                    scrollingPanLastMouseLocal = dragStartMouseLocal;
-                    updateScrollingPan();
                 }
             }
 
@@ -938,11 +984,8 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
             if (!dragActiveWindow && !scrollingPanPointerDown && dragStartMouseLocal.distanceSq(lastMousePosLocal) > DRAGTHRESHOLDSQ) {
                 if (!INVERT_DRAG_MODE) {
                     beginWindowDrag(windowAtOverviewPoint(dragStartMouseLocal));
-                } else if (const auto WORKSPACE = workspaceAtOverviewPoint(dragStartMouseLocal); isWorkspaceScrolling(WORKSPACE)) {
-                    beginScrollingPan(WORKSPACE);
-                    scrollingPanLastMouseLocal = dragStartMouseLocal;
-                    updateScrollingPan();
-                }
+                } else
+                    beginScrollingPanAtPoint(dragStartMouseLocal);
             }
 
             if (dragActiveWindow)
@@ -1027,6 +1070,41 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
             selectWindowAtOverviewCursor(true);
             close();
         };
+        const auto     finishWindowDragOrClick = [&](uint32_t button, bool allowClick) {
+            const float CLICK_MAX_DRAG_DISTANCE = 10.F * (pMonitor ? pMonitor->m_scale : 1.F);
+
+            if (dragActiveWindow) {
+                if (dragStartMouseLocal.distanceSq(lastMousePosLocal) < CLICK_MAX_DRAG_DISTANCE * CLICK_MAX_DRAG_DISTANCE) {
+                    clearDragPending();
+
+                    if (allowClick)
+                        performClickAction(button);
+                    else
+                        clearSubmapMouseClickPending();
+
+                    return;
+                }
+
+                endWindowDrag();
+                clearSubmapMouseClickPending();
+                return;
+            }
+
+            clearDragPending();
+
+            if (allowClick)
+                performClickAction(button);
+            else
+                clearSubmapMouseClickPending();
+        };
+        const auto     workspaceAtPanPoint = [&](const Vector2D& point) {
+            auto WORKSPACE = workspaceAtOverviewPoint(point);
+            if (WORKSPACE)
+                return WORKSPACE;
+
+            const auto WINDOW = windowAtOverviewPoint(point);
+            return WINDOW ? WINDOW->m_workspace : PHLWORKSPACE{};
+        };
 
         if (event.button == MAIN_BUTTON) {
             lastMousePosLocal = getOverviewMousePosLocal(pMonitor.lock());
@@ -1044,37 +1122,7 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
             if (scrollingPanPointerDown)
                 endScrollingPan();
 
-            const float CLICK_MAX_DRAG_DISTANCE = 10.F * (pMonitor ? pMonitor->m_scale : 1.F);
-
-            if (dragActiveWindow) {
-                if (dragStartMouseLocal.distanceSq(lastMousePosLocal) < CLICK_MAX_DRAG_DISTANCE * CLICK_MAX_DRAG_DISTANCE) {
-                    clearDragPending();
-                    dragActiveWindow.reset();
-                    dragOriginalWorkspace.reset();
-                    dragStartedTiled      = false;
-                    dragOriginalFloatSize = Vector2D{};
-                    dragGrabOffsetLocal   = Vector2D{};
-                    dragOriginalBox       = CBox{};
-
-                    if (!WASPANNING)
-                        performClickAction(event.button);
-                    else
-                        clearSubmapMouseClickPending();
-
-                    return;
-                }
-
-                endWindowDrag();
-                clearSubmapMouseClickPending();
-                return;
-            }
-
-            clearDragPending();
-
-            if (!WASPANNING)
-                performClickAction(event.button);
-            else
-                clearSubmapMouseClickPending();
+            finishWindowDragOrClick(event.button, !WASPANNING);
             return;
         }
 
@@ -1085,8 +1133,8 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
                 if (beginSubmapMouseClickPending(event.button))
                     return;
 
-                size_t workspaceIdx = 0;
-                const auto WORKSPACE = workspaceAtOverviewCursor(&workspaceIdx);
+                const auto WORKSPACE = workspaceAtPanPoint(lastMousePosLocal);
+
                 if (!isWorkspaceScrolling(WORKSPACE)) {
                     scrollingPanPointerDown = false;
                     return;
@@ -1171,29 +1219,7 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
             return;
         }
 
-        const float CLICK_MAX_DRAG_DISTANCE = 10.F * (pMonitor ? pMonitor->m_scale : 1.F);
-
-        if (dragActiveWindow && dragStartMouseLocal.distanceSq(lastMousePosLocal) < CLICK_MAX_DRAG_DISTANCE * CLICK_MAX_DRAG_DISTANCE) {
-            clearDragPending();
-            dragActiveWindow.reset();
-            dragOriginalWorkspace.reset();
-            dragStartedTiled      = false;
-            dragOriginalFloatSize = Vector2D{};
-            dragGrabOffsetLocal   = Vector2D{};
-            dragOriginalBox       = CBox{};
-
-            performClickAction(event.button);
-            return;
-        }
-
-        if (dragActiveWindow) {
-            endWindowDrag();
-            return;
-        }
-
-        clearDragPending();
-
-        performClickAction(event.button);
+        finishWindowDragOrClick(event.button, true);
     };
 
     auto onCursorSelect = [this](auto, Event::SCallbackInfo& info) {
@@ -1654,9 +1680,17 @@ void CScrollOverview::rebuildWorkspaceImages() {
 
     viewportCurrentWorkspace = 0;
     for (size_t i = 0; i < images.size(); ++i) {
-        if (images[i]->pWorkspace == viewportWorkspace || images[i]->pWorkspace == selectedWorkspace) {
+        if (images[i]->pWorkspace == viewportWorkspace) {
             viewportCurrentWorkspace = i;
             break;
+        }
+    }
+    if (images[viewportCurrentWorkspace]->pWorkspace != viewportWorkspace) {
+        for (size_t i = 0; i < images.size(); ++i) {
+            if (images[i]->pWorkspace == selectedWorkspace) {
+                viewportCurrentWorkspace = i;
+                break;
+            }
         }
     }
 
@@ -1856,6 +1890,136 @@ PHLWINDOW CScrollOverview::windowAtOverviewCursorOnWorkspace(size_t workspaceIdx
     return bestWindow;
 }
 
+CDropIndicator::SDropAnchor CScrollOverview::dropAnchorAtOverviewCursorOnWorkspace(size_t workspaceIdx, const PHLWINDOW& ignoredWindow) {
+    CDropIndicator::SDropAnchor result;
+
+    const auto MONITOR = pMonitor.lock();
+    if (!MONITOR || workspaceIdx >= images.size() || !images[workspaceIdx])
+        return result;
+
+    const auto& IMAGE     = images[workspaceIdx];
+    const auto  WORKSPACE = IMAGE->pWorkspace;
+    if (!WORKSPACE)
+        return result;
+
+    const auto WORKSPACE_OFFSET =
+        workspaceOverviewOffset(workspaceIdx, activeWorkspaceIndex(), getWorkspaceRenderedPitch(MONITOR, scale->value(), layout));
+    const auto WORKSPACEBOX = getOverviewWorkspaceBox(MONITOR, scale->value(), viewOffset->value(), WORKSPACE_OFFSET, layout);
+
+    if (!overviewBoxFullyVisibleOnMonitor(WORKSPACEBOX, MONITOR))
+        return result;
+
+    if (!dragStartedTiled)
+        return result;
+
+    const auto boxesForWindow = [&](const PHLWINDOW& window) {
+        const auto TARGET = window->layoutTarget();
+        return std::pair{
+            getOverviewWindowBox(window, MONITOR, scale->value(), viewOffset->value(), WORKSPACE_OFFSET, layout, false),
+            TARGET ? getOverviewGlobalBox(TARGET->position(), MONITOR, scale->value(), viewOffset->value(), WORKSPACE_OFFSET, layout, false) : CBox{},
+        };
+    };
+    const auto setAnchor = [](CDropIndicator::SDropAnchor& anchor, const PHLWINDOW& window, const CBox& box, const CBox& logicalBox = {}, const std::string& direction = {}) {
+        anchor.window     = window;
+        anchor.box        = box;
+        anchor.logicalBox = logicalBox;
+        anchor.direction  = direction;
+    };
+
+    const auto directionForBox = [&](const CBox& box) {
+        const auto LOCAL_X = lastMousePosLocal.x - box.x;
+        const auto LOCAL_Y = lastMousePosLocal.y - box.y;
+
+        if (LOCAL_X < box.width / 3.F)
+            return std::string{"l"};
+        if (LOCAL_X > box.width * 2.F / 3.F)
+            return std::string{"r"};
+        return LOCAL_Y < box.height / 2.F ? std::string{"u"} : std::string{"d"};
+    };
+
+    refreshDragOriginalOverviewBoxes();
+
+    const auto ORIGINALHITBOX = dragOriginalOverviewHitbox.empty() ? dragOriginalOverviewBox : dragOriginalOverviewHitbox;
+    if (ignoredWindow && !dragOriginalOverviewBox.empty() && ORIGINALHITBOX.containsPoint(lastMousePosLocal) && WORKSPACE == dragOriginalWorkspace.lock()) {
+        setAnchor(result, ignoredWindow, dragOriginalOverviewBox);
+        return result;
+    }
+
+    float bestDistanceSq = std::numeric_limits<float>::max();
+    for (auto it = IMAGE->windows.rbegin(); it != IMAGE->windows.rend(); ++it) {
+        const auto WINDOW = getOverviewWindowToShow(it->lock());
+        if (!shouldShowOverviewWindow(WINDOW) || WINDOW == ignoredWindow || WINDOW->m_isFloating)
+            continue;
+
+        const auto [BOX, LOGICALBOX] = boxesForWindow(WINDOW);
+        const auto HITBOX            = LOGICALBOX.empty() ? BOX : LOGICALBOX;
+
+        if (!HITBOX.containsPoint(lastMousePosLocal))
+            continue;
+
+        const auto distanceSq = overviewPointDistanceSqToBox(lastMousePosLocal, BOX);
+        if (distanceSq >= bestDistanceSq)
+            continue;
+
+        setAnchor(result, WINDOW, BOX, LOGICALBOX, directionForBox(BOX));
+        bestDistanceSq = distanceSq;
+    }
+
+    if (result.window)
+        return result;
+
+    const auto ALGO      = overviewScrollingAlgorithmForWorkspace(WORKSPACE);
+    if (!ALGO || !ALGO->m_scrollingData || !ALGO->m_scrollingData->controller)
+        return result;
+
+    const bool PRIMARYHORIZONTAL = ALGO->m_scrollingData->controller->isPrimaryHorizontal();
+
+    const auto POINTER   = PRIMARYHORIZONTAL ? sc<float>(lastMousePosLocal.x) : sc<float>(lastMousePosLocal.y);
+    float      firstEdge = std::numeric_limits<float>::max();
+    float      lastEdge  = std::numeric_limits<float>::lowest();
+
+    for (const auto& windowRef : IMAGE->windows) {
+        const auto WINDOW = getOverviewWindowToShow(windowRef.lock());
+        if (!shouldShowOverviewWindow(WINDOW) || WINDOW == ignoredWindow || WINDOW->m_isFloating)
+            continue;
+
+        const auto [BOX, LOGICALBOX] = boxesForWindow(WINDOW);
+        const auto HITBOX            = LOGICALBOX.empty() ? BOX : LOGICALBOX;
+        const auto MIN               = PRIMARYHORIZONTAL ? sc<float>(HITBOX.x) : sc<float>(HITBOX.y);
+        const auto MAX               = PRIMARYHORIZONTAL ? sc<float>(HITBOX.x + HITBOX.width) : sc<float>(HITBOX.y + HITBOX.height);
+
+        firstEdge = std::min(firstEdge, MIN);
+        lastEdge  = std::max(lastEdge, MAX);
+    }
+
+    if (POINTER >= firstEdge && POINTER <= lastEdge)
+        return result;
+
+    const bool FIND_FIRST = POINTER < firstEdge;
+    float      bestEdge   = FIND_FIRST ? std::numeric_limits<float>::max() : std::numeric_limits<float>::lowest();
+
+    for (const auto& windowRef : IMAGE->windows) {
+        const auto WINDOW = getOverviewWindowToShow(windowRef.lock());
+        if (!shouldShowOverviewWindow(WINDOW) || WINDOW == ignoredWindow || WINDOW->m_isFloating)
+            continue;
+
+        const auto [BOX, LOGICALBOX] = boxesForWindow(WINDOW);
+        const auto HITBOX            = LOGICALBOX.empty() ? BOX : LOGICALBOX;
+        const auto EDGE              = PRIMARYHORIZONTAL ? sc<float>(FIND_FIRST ? HITBOX.x : HITBOX.x + HITBOX.width) :
+                                                           sc<float>(FIND_FIRST ? HITBOX.y : HITBOX.y + HITBOX.height);
+
+        if (FIND_FIRST ? EDGE < bestEdge : EDGE > bestEdge) {
+            bestEdge = EDGE;
+            setAnchor(result, WINDOW, BOX, LOGICALBOX);
+        }
+    }
+
+    if (result.window)
+        result.direction = PRIMARYHORIZONTAL ? (FIND_FIRST ? "l" : "r") : (FIND_FIRST ? "u" : "d");
+
+    return result;
+}
+
 PHLWORKSPACE CScrollOverview::workspaceAtOverviewPoint(const Vector2D& point, size_t* hoveredWorkspaceIdx) const {
     const auto MONITOR = pMonitor.lock();
     if (!MONITOR)
@@ -1866,12 +2030,11 @@ PHLWORKSPACE CScrollOverview::workspaceAtOverviewPoint(const Vector2D& point, si
         if (!wimg || !wimg->pWorkspace)
             continue;
 
-        const auto WORKSPACEBOX = getOverviewWorkspaceBox(MONITOR, scale->value(), viewOffset->value(),
-                                                          workspaceOverviewOffset(workspaceIdx, activeWorkspaceIndex(), getWorkspaceRenderedPitch(MONITOR, scale->value(), layout)),
-                                                          layout);
-        const auto VISIBLEBOX   = workspaceOverviewVisibleBox(workspaceIdx, WORKSPACEBOX, scale->value(), MONITOR);
+        const auto WORKSPACEBOX = getOverviewWorkspaceUsableBox(wimg->pWorkspace, MONITOR, scale->value(), viewOffset->value(),
+                                                                workspaceOverviewOffset(workspaceIdx, activeWorkspaceIndex(), getWorkspaceRenderedPitch(MONITOR, scale->value(), layout)),
+                                                                layout);
 
-        if (VISIBLEBOX.containsPoint(point)) {
+        if (WORKSPACEBOX.containsPoint(point)) {
             if (hoveredWorkspaceIdx)
                 *hoveredWorkspaceIdx = workspaceIdx;
 
@@ -1892,15 +2055,14 @@ PHLWORKSPACE CScrollOverview::workspaceAtOverviewDropPoint(const Vector2D& point
         if (!wimg || !wimg->pWorkspace)
             continue;
 
-        const auto WORKSPACEBOX = getOverviewWorkspaceBox(MONITOR, scale->value(), viewOffset->value(),
-                                                          workspaceOverviewOffset(workspaceIdx, activeWorkspaceIndex(), getWorkspaceRenderedPitch(MONITOR, scale->value(), layout)),
-                                                          layout);
-        const auto VISIBLEBOX   = workspaceOverviewVisibleBox(workspaceIdx, WORKSPACEBOX, scale->value(), MONITOR);
+        const auto WORKSPACEBOX = getOverviewWorkspaceUsableBox(wimg->pWorkspace, MONITOR, scale->value(), viewOffset->value(),
+                                                                workspaceOverviewOffset(workspaceIdx, activeWorkspaceIndex(), getWorkspaceRenderedPitch(MONITOR, scale->value(), layout)),
+                                                                layout);
         const bool ONLAYOUTAXIS = layout == ScrollOverview::Config::ELayout::HORIZONTAL ?
-            point.x >= VISIBLEBOX.x && point.x <= VISIBLEBOX.x + VISIBLEBOX.width :
-            point.y >= VISIBLEBOX.y && point.y <= VISIBLEBOX.y + VISIBLEBOX.height;
+            point.x >= WORKSPACEBOX.x && point.x <= WORKSPACEBOX.x + WORKSPACEBOX.width :
+            point.y >= WORKSPACEBOX.y && point.y <= WORKSPACEBOX.y + WORKSPACEBOX.height;
 
-        if (VISIBLEBOX.containsPoint(point) || (ONLAYOUTAXIS && isWorkspaceScrolling(wimg->pWorkspace))) {
+        if (WORKSPACEBOX.containsPoint(point) || (ONLAYOUTAXIS && isWorkspaceScrolling(wimg->pWorkspace))) {
             if (hoveredWorkspaceIdx)
                 *hoveredWorkspaceIdx = workspaceIdx;
 
@@ -2025,6 +2187,38 @@ CBox CScrollOverview::draggedWindowBox(size_t workspaceIdx) const {
     return box;
 }
 
+void CScrollOverview::refreshDragOriginalOverviewBoxes() {
+    const auto WINDOW    = getOverviewWindowToShow(dragActiveWindow.lock());
+    const auto WORKSPACE = dragOriginalWorkspace.lock();
+    const auto MONITOR   = pMonitor.lock();
+    if (!WINDOW || !WORKSPACE || !MONITOR || dragOriginalVisualBox.empty() || dragOriginalBox.empty())
+        return;
+
+    size_t workspaceIdx = images.size();
+    for (size_t i = 0; i < images.size(); ++i) {
+        if (images[i] && images[i]->pWorkspace == WORKSPACE) {
+            workspaceIdx = i;
+            break;
+        }
+    }
+
+    if (workspaceIdx >= images.size())
+        return;
+
+    Vector2D tapeDelta;
+    if (const auto ALGO = overviewScrollingAlgorithmForWorkspace(WORKSPACE); ALGO && ALGO->m_scrollingData && ALGO->m_scrollingData->controller)
+        tapeDelta = ALGO->m_scrollingData->controller->getCameraTranslation(ALGO->usableArea()) - dragOriginalTapeTranslation;
+
+    auto visualBox = dragOriginalVisualBox;
+    auto hitbox    = dragOriginalBox;
+    visualBox.translate(tapeDelta);
+    hitbox.translate(tapeDelta);
+
+    const auto WORKSPACEOFFSET = workspaceOverviewOffset(workspaceIdx, activeWorkspaceIndex(), getWorkspaceRenderedPitch(MONITOR, scale->value(), layout));
+    dragOriginalOverviewBox    = getOverviewGlobalBox(visualBox, MONITOR, scale->value(), viewOffset->value(), WORKSPACEOFFSET, layout);
+    dragOriginalOverviewHitbox = getOverviewGlobalBox(hitbox, MONITOR, scale->value(), viewOffset->value(), WORKSPACEOFFSET, layout, false);
+}
+
 CBox CScrollOverview::resizedWindowBox() const {
     const auto WINDOW  = getOverviewWindowToShow(resizeActiveWindow.lock());
     const auto MONITOR = pMonitor.lock();
@@ -2073,18 +2267,25 @@ void CScrollOverview::beginWindowDrag(PHLWINDOW window) {
         }
     }
 
-    const auto TARGET       = WINDOW->layoutTarget();
-    dragStartedTiled        = !TARGET->floating();
-    dragOriginalFloatSize   = TARGET->lastFloatingSize();
-    dragOriginalWorkspace   = WINDOW->m_workspace;
-    dragOriginalBox          = TARGET->position();
-    dragActiveWindow         = WINDOW;
+    const auto TARGET             = WINDOW->layoutTarget();
+    dragStartedTiled              = !TARGET->floating();
+    dragOriginalFloatSize         = TARGET->lastFloatingSize();
+    dragOriginalTapeTranslation  = Vector2D{};
+    dragOriginalWorkspace         = WINDOW->m_workspace;
+    dragOriginalBox               = TARGET->position();
+    dragOriginalVisualBox         = {WINDOW->m_realPosition->value(), WINDOW->m_realSize->value()};
+    dragOriginalOverviewBox       = CBox{};
+    dragOriginalOverviewHitbox    = CBox{};
+    dragActiveWindow              = WINDOW;
 
     const auto MONITOR = pMonitor.lock();
     if (MONITOR && workspaceIdx < images.size()) {
         const auto WORKSPACEOFFSET = workspaceOverviewOffset(workspaceIdx, activeWorkspaceIndex(), getWorkspaceRenderedPitch(MONITOR, scale->value(), layout));
         const auto WINDOWBOX       = getOverviewWindowBox(WINDOW, MONITOR, scale->value(), viewOffset->value(), WORKSPACEOFFSET, layout);
         dragGrabOffsetLocal        = dragStartMouseLocal - WINDOWBOX.pos();
+        if (const auto ALGO = overviewScrollingAlgorithmForWorkspace(WINDOW->m_workspace); ALGO && ALGO->m_scrollingData && ALGO->m_scrollingData->controller)
+            dragOriginalTapeTranslation = ALGO->m_scrollingData->controller->getCameraTranslation(ALGO->usableArea());
+        refreshDragOriginalOverviewBoxes();
     } else
         dragGrabOffsetLocal = Vector2D{};
 
@@ -2158,7 +2359,17 @@ void CScrollOverview::updateWindowResize() {
 }
 
 void CScrollOverview::clearDragPending() {
-    dragPendingPrimary = false;
+    dragPendingPrimary          = false;
+    dragActiveWindow.reset();
+    dragOriginalWorkspace.reset();
+    dragStartedTiled            = false;
+    dragOriginalFloatSize       = Vector2D{};
+    dragOriginalTapeTranslation = Vector2D{};
+    dragGrabOffsetLocal         = Vector2D{};
+    dragOriginalBox             = CBox{};
+    dragOriginalVisualBox       = CBox{};
+    dragOriginalOverviewBox     = CBox{};
+    dragOriginalOverviewHitbox  = CBox{};
 }
 
 void CScrollOverview::updateScrollingPan() {
@@ -2179,7 +2390,7 @@ void CScrollOverview::updateScrollingPan() {
     const auto DELTA       = ALGO->m_scrollingData->controller->isPrimaryHorizontal() ? DELTAGLOBAL.x : DELTAGLOBAL.y;
 
     if (std::abs(DELTA) > 0.01F) {
-        const double OFFSET = clampOverviewScrollingOffset(ALGO, ALGO->m_scrollingData->controller->getOffset() - DELTA);
+        const double OFFSET = ALGO->m_scrollingData->controller->getOffset() - DELTA;
         ALGO->m_scrollingData->controller->setOffset(OFFSET);
         ALGO->m_scrollingData->lockedCameraOffset = OFFSET;
         ALGO->m_scrollingData->recalculate(true);
@@ -2203,7 +2414,7 @@ void CScrollOverview::beginScrollingPan(PHLWORKSPACE workspace) {
     if (scrollingPanInitialWindow && scrollingPanInitialWindow->m_workspace != workspace)
         scrollingPanInitialWindow.reset();
 
-    ALGO->m_scrollingData->lockedCameraOffset = clampOverviewScrollingOffset(ALGO, ALGO->m_scrollingData->controller->getOffset());
+    ALGO->m_scrollingData->lockedCameraOffset = ALGO->m_scrollingData->controller->getOffset();
 
     if (Desktop::focusState()->window() && Desktop::focusState()->window()->m_workspace == workspace)
         Desktop::focusState()->fullWindowFocus(nullptr, Desktop::FOCUS_REASON_DESKTOP_STATE_CHANGE);
@@ -2212,8 +2423,12 @@ void CScrollOverview::beginScrollingPan(PHLWORKSPACE workspace) {
 void CScrollOverview::endScrollingPan() {
     const auto WORKSPACE = scrollingPanWorkspace.lock();
     const auto ALGO      = overviewScrollingAlgorithmForWorkspace(WORKSPACE);
-    if (ALGO)
+    if (ALGO) {
+        const double OFFSET = clampOverviewScrollingOffset(ALGO, ALGO->m_scrollingData->controller->getOffset());
+        ALGO->m_scrollingData->controller->setOffset(OFFSET);
         ALGO->m_scrollingData->lockedCameraOffset.reset();
+        ALGO->m_scrollingData->recalculate();
+    }
 
     scrollingPanPointerDown    = false;
     scrollingPanLastMouseLocal = Vector2D{};
@@ -2381,31 +2596,20 @@ void CScrollOverview::endWindowDrag() {
     const bool          RETILEONEND      = dragStartedTiled && TARGET && SPACE && ALGO;
     size_t              dropWorkspaceIdx = 0;
     const auto          DROPWORKSPACE    = workspaceAtOverviewDropPoint(lastMousePosLocal, &dropWorkspaceIdx);
-    const auto          SELECTEDWORKSPACE =
-        viewportCurrentWorkspace < images.size() && images[viewportCurrentWorkspace] ? images[viewportCurrentWorkspace]->pWorkspace : PHLWORKSPACE{};
     const auto          DROPSCROLLINGALGO  = overviewScrollingAlgorithmForWorkspace(DROPWORKSPACE);
     const bool          DROPSCROLLINGLAYOUT = DROPSCROLLINGALGO != nullptr;
     const bool          DROPSCROLLINGPRIMARYHORIZONTAL =
         DROPSCROLLINGALGO && DROPSCROLLINGALGO->m_scrollingData && DROPSCROLLINGALGO->m_scrollingData->controller &&
         DROPSCROLLINGALGO->m_scrollingData->controller->isPrimaryHorizontal();
-    const bool          DROPONSELECTEDWORKSPACE = DROPWORKSPACE && DROPWORKSPACE == SELECTEDWORKSPACE;
     const auto          ORIGINALWORKSPACE = dragOriginalWorkspace.lock();
     const bool          MOVEWORKSPACE    = DROPWORKSPACE && DROPWORKSPACE != ORIGINALWORKSPACE;
     const auto          DRAGBOX          = DROPWORKSPACE ? draggedWindowBox(dropWorkspaceIdx) : CBox{};
     int                 dropSide         = 0;
-    CBox                dropAnchorOverviewBox;
-    const auto          DROPANCHOR = DROPWORKSPACE ? windowAtOverviewCursorOnWorkspace(dropWorkspaceIdx, WINDOW, &dropAnchorOverviewBox) : PHLWINDOW{};
+    CDropIndicator::SDropAnchor dropAnchor;
     std::string         dropDirection;
-    bool movedToWorkspace = false;
 
     if (!DROPWORKSPACE) {
         clearDragPending();
-        dragActiveWindow.reset();
-        dragOriginalWorkspace.reset();
-        dragStartedTiled      = false;
-        dragOriginalFloatSize = Vector2D{};
-        dragGrabOffsetLocal   = Vector2D{};
-        dragOriginalBox       = CBox{};
         damage();
         return;
     }
@@ -2417,15 +2621,29 @@ void CScrollOverview::endWindowDrag() {
     const bool DROPSIDEHORIZONTAL = layout != ScrollOverview::Config::ELayout::HORIZONTAL || DROPSCROLLINGPRIMARYHORIZONTAL;
 
     const auto MONITOR = pMonitor.lock();
+    const auto ACTIVEWORKSPACEBEFOREDROP = MONITOR ? MONITOR->m_activeWorkspace : PHLWORKSPACE{};
+    const auto RESTOREACTIVEWORKSPACE = [&]() {
+        if (MONITOR && ACTIVEWORKSPACEBEFOREDROP && MONITOR->m_activeWorkspace != ACTIVEWORKSPACEBEFOREDROP)
+            MONITOR->changeWorkspace(ACTIVEWORKSPACEBEFOREDROP, false, true, true);
+    };
+    const auto RESTOREVIEWPORTWORKSPACE = [&]() {
+        if (!ACTIVEWORKSPACEBEFOREDROP)
+            return;
+
+        for (size_t i = 0; i < images.size(); ++i) {
+            if (images[i] && images[i]->pWorkspace == ACTIVEWORKSPACEBEFOREDROP) {
+                viewportCurrentWorkspace = i;
+                return;
+            }
+        }
+    };
+
     bool       dropWorkspaceFullyVisible = false;
     if (MONITOR) {
         const auto WORKSPACEBOX =
             getOverviewWorkspaceBox(MONITOR, scale->value(), viewOffset->value(),
                                     workspaceOverviewOffset(dropWorkspaceIdx, activeWorkspaceIndex(), getWorkspaceRenderedPitch(MONITOR, scale->value(), layout)), layout);
-        const CBox VIEWPORT = {{}, MONITOR->m_size * MONITOR->m_scale};
-
-        dropWorkspaceFullyVisible = WORKSPACEBOX.x >= VIEWPORT.x && WORKSPACEBOX.y >= VIEWPORT.y &&
-            WORKSPACEBOX.x + WORKSPACEBOX.width <= VIEWPORT.x + VIEWPORT.width && WORKSPACEBOX.y + WORKSPACEBOX.height <= VIEWPORT.y + VIEWPORT.height;
+        dropWorkspaceFullyVisible = overviewBoxFullyVisibleOnMonitor(WORKSPACEBOX, MONITOR);
 
         if (DROPSIDEHORIZONTAL) {
             if (lastMousePosLocal.x < WORKSPACEBOX.x)
@@ -2440,69 +2658,38 @@ void CScrollOverview::endWindowDrag() {
         }
     }
 
-    if (!DROPANCHOR && dropSide == 0 && DROPSIDEHORIZONTAL && MONITOR && dropWorkspaceIdx < images.size() && images[dropWorkspaceIdx]) {
-        const auto WORKSPACE_OFFSET = workspaceOverviewOffset(dropWorkspaceIdx, activeWorkspaceIndex(), getWorkspaceRenderedPitch(MONITOR, scale->value(), layout));
+    if (DROPWORKSPACE)
+        dropAnchor = dropAnchorAtOverviewCursorOnWorkspace(dropWorkspaceIdx, WINDOW);
 
-        float minWindowX = std::numeric_limits<float>::max();
-        float maxWindowX = std::numeric_limits<float>::lowest();
-        bool  foundWindow = false;
-
-        for (const auto& windowRef : images[dropWorkspaceIdx]->windows) {
-            const auto OTHERWINDOW = getOverviewWindowToShow(windowRef.lock());
-            if (!shouldShowOverviewWindow(OTHERWINDOW) || OTHERWINDOW == WINDOW)
-                continue;
-
-            const auto BOX = getOverviewWindowBox(OTHERWINDOW, MONITOR, scale->value(), viewOffset->value(), WORKSPACE_OFFSET, layout);
-            minWindowX     = std::min(minWindowX, sc<float>(BOX.x));
-            maxWindowX     = std::max(maxWindowX, sc<float>(BOX.x + BOX.width));
-            foundWindow    = true;
-        }
-
-        if (foundWindow) {
-            if (lastMousePosLocal.x < minWindowX)
-                dropSide = -1;
-            else if (lastMousePosLocal.x > maxWindowX)
-                dropSide = 1;
-        }
-    }
-
-    if (DROPANCHOR && DROPSCROLLINGLAYOUT) {
-        const auto LOCAL_X = lastMousePosLocal.x - dropAnchorOverviewBox.x;
-        const auto LOCAL_Y = lastMousePosLocal.y - dropAnchorOverviewBox.y;
-
-        if (LOCAL_X < dropAnchorOverviewBox.width / 3.F)
-            dropDirection = "l";
-        else if (LOCAL_X > dropAnchorOverviewBox.width * 2.F / 3.F)
-            dropDirection = "r";
-        else
-            dropDirection = LOCAL_Y < dropAnchorOverviewBox.height / 2.F ? "u" : "d";
-
-    }
+    const auto DROPANCHOR = dropAnchor.window;
+    dropDirection         = dropAnchor.direction;
 
     if (RETILEONEND && MOVEWORKSPACE) {
         g_pCompositor->moveWindowToWorkspaceSafe(WINDOW, DROPWORKSPACE);
-        movedToWorkspace = true;
+        RESTOREACTIVEWORKSPACE();
 
         if (DROPSCROLLINGLAYOUT) {
             if (!dropWorkspaceFullyVisible)
                 moveOverviewScrollingTargetToWorkspaceEdge(TARGET, 1);
             else if (DROPANCHOR && !dropDirection.empty())
                 moveOverviewTargetNextToWindow(TARGET, DROPANCHOR, dropDirection);
-            else
+            else if (!DROPANCHOR)
                 moveOverviewScrollingTargetToWorkspaceEdge(TARGET, dropSide);
         }
 
         TARGET->rememberFloatingSize(dragOriginalFloatSize);
+        RESTOREACTIVEWORKSPACE();
+        RESTOREVIEWPORTWORKSPACE();
     } else if (RETILEONEND) {
         TARGET->damageEntire();
 
-        if (DROPANCHOR && !DROPSCROLLINGLAYOUT && DROPANCHOR->layoutTarget()) {
+        if (DROPANCHOR && !dropDirection.empty() && !DROPSCROLLINGLAYOUT && DROPANCHOR->layoutTarget()) {
             DROPANCHOR->layoutTarget()->damageEntire();
             g_layoutManager->switchTargets(TARGET, DROPANCHOR->layoutTarget(), true);
             DROPANCHOR->layoutTarget()->damageEntire();
         } else if (DROPANCHOR && !dropDirection.empty())
             moveOverviewTargetNextToWindow(TARGET, DROPANCHOR, dropDirection);
-        else if (DROPSCROLLINGLAYOUT)
+        else if (DROPSCROLLINGLAYOUT && !DROPANCHOR)
             moveOverviewScrollingTargetToWorkspaceEdge(TARGET, dropSide);
 
         TARGET->rememberFloatingSize(dragOriginalFloatSize);
@@ -2512,20 +2699,24 @@ void CScrollOverview::endWindowDrag() {
         Desktop::focusState()->fullWindowFocus(WINDOW, Desktop::FOCUS_REASON_DESKTOP_STATE_CHANGE);
 
         if (const auto WORKSPACE = SPACE->workspace())
-            WORKSPACE->updateWindows();
+        WORKSPACE->updateWindows();
     } else if (WINDOW && MOVEWORKSPACE) {
         g_pCompositor->moveWindowToWorkspaceSafe(WINDOW, DROPWORKSPACE);
-        movedToWorkspace = true;
+        RESTOREACTIVEWORKSPACE();
+
         if (TARGET) {
             const auto GLOBALSIZE = DRAGBOX.size() * (1.F / (std::max(scale->value(), 0.01F) * std::max(MONITOR ? MONITOR->m_scale : 1.F, 0.01F)));
-            auto       GLOBALBOX  = DROPONSELECTEDWORKSPACE ? CBox{overviewPointToGlobal(dropWorkspaceIdx, DRAGBOX.pos()), GLOBALSIZE} :
-                                                               centerBoxInWorkspace(CBox{Vector2D{}, GLOBALSIZE}, DROPWORKSPACE, MONITOR);
-            if (DROPONSELECTEDWORKSPACE)
+            auto       GLOBALBOX  = dropWorkspaceFullyVisible ? CBox{overviewPointToGlobal(dropWorkspaceIdx, DRAGBOX.pos()), GLOBALSIZE} :
+                                                                centerBoxInWorkspace(CBox{Vector2D{}, GLOBALSIZE}, DROPWORKSPACE, MONITOR);
+            if (dropWorkspaceFullyVisible)
                 GLOBALBOX = clampBoxToWorkspace(GLOBALBOX, DROPWORKSPACE, MONITOR, WINDOW->getRealBorderSize());
 
             TARGET->setPositionGlobal(GLOBALBOX);
             TARGET->warpPositionSize();
         }
+
+        RESTOREACTIVEWORKSPACE();
+        RESTOREVIEWPORTWORKSPACE();
     } else if (TARGET && !dragStartedTiled) {
         const auto workspaceIdx = dragWorkspaceIndex(WINDOW);
 
@@ -2561,18 +2752,7 @@ void CScrollOverview::endWindowDrag() {
     }
 
     clearDragPending();
-    dragActiveWindow.reset();
-    dragOriginalWorkspace.reset();
-    dragStartedTiled              = false;
-    dragOriginalFloatSize         = Vector2D{};
-    dragGrabOffsetLocal           = Vector2D{};
-    dragOriginalBox               = CBox{};
-    rebuildPending                = true;
-    if (movedToWorkspace && ORIGINALWORKSPACE && !ORIGINALWORKSPACE->m_isSpecialWorkspace && !ORIGINALWORKSPACE->isPersistent() && ORIGINALWORKSPACE->getWindows() == 0) {
-        pendingRemovedWorkspace = ORIGINALWORKSPACE;
-        rebuildPending          = false;
-        onWorkspaceChange();
-    }
+    rebuildPending = true;
     damage();
 }
 
@@ -3335,6 +3515,33 @@ void CScrollOverview::renderWorkspaceLive(PHLMONITOR monitor, size_t workspaceId
     const auto fullscreenWindow = getOverviewWindowToShow(workspace->getFullscreenWindow());
     const bool scrollingLayout   = isWorkspaceScrolling(workspace);
     const bool hasFullscreenPath = shouldShowOverviewWindow(fullscreenWindow) && fullscreenWindow->m_workspace == workspace;
+    const auto renderDropIndicator = [&] {
+        if (hasRunningWorkspaceAnimation())
+            return;
+
+        const auto DRAGGED = getOverviewWindowToShow(dragActiveWindow.lock());
+        if (!DRAGGED)
+            return;
+
+        size_t     dropWorkspaceIdx = 0;
+        const auto DROPWORKSPACE    = workspaceAtOverviewDropPoint(lastMousePosLocal, &dropWorkspaceIdx);
+        if (DROPWORKSPACE != workspace || dropWorkspaceIdx != workspaceIdx)
+            return;
+
+        const auto ANCHOR = dropAnchorAtOverviewCursorOnWorkspace(workspaceIdx, DRAGGED);
+        const auto WORKSPACEBOX = getOverviewWorkspaceBox(monitor, renderScale, viewOffset->value(), WORKSPACEOFFSET, layout);
+
+        CDropIndicator::renderDropIndicator({
+            .monitor                    = monitor,
+            .workspace                  = workspace,
+            .workspaceUsableBox         = getOverviewWorkspaceUsableBox(workspace, monitor, renderScale, viewOffset->value(), WORKSPACEOFFSET, layout),
+            .anchor                     = ANCHOR,
+            .renderScale                = renderScale,
+            .workspaceFullyVisible      = overviewBoxFullyVisibleOnMonitor(WORKSPACEBOX, monitor),
+            .layout                     = layout,
+        });
+    };
+
     if (!scrollingLayout && hasFullscreenPath) {
         renderOverviewWindow(fullscreenWindow);
         OverviewRender::flushPass(monitor);
@@ -3345,6 +3552,7 @@ void CScrollOverview::renderWorkspaceLive(PHLMONITOR monitor, size_t workspaceId
 
             renderOverviewWindow(window);
         }
+        renderDropIndicator();
         return;
     }
 
@@ -3360,6 +3568,7 @@ void CScrollOverview::renderWorkspaceLive(PHLMONITOR monitor, size_t workspaceId
 
     renderWindowsByState(false);
     renderWindowsByState(true);
+    renderDropIndicator();
 }
 
 void CScrollOverview::renderDraggedWindow(PHLMONITOR monitor, size_t activeIdx, float workspacePitch, float renderScale, const Time::steady_tp& now) {
@@ -3673,6 +3882,10 @@ int CScrollOverview::realtimePreviewTimerCallback(void* data) {
     OVERVIEW->damage();
     OVERVIEW->scheduleMinimumPreviewFrame();
     return 0;
+}
+
+bool CScrollOverview::hasRunningWorkspaceAnimation() const {
+    return viewOffset->isBeingAnimated() || workspaceInsertProgress->isBeingAnimated() || workspaceInsertFadeProgress->isBeingAnimated();
 }
 
 bool CScrollOverview::shouldSuppressRenderDamage() const {
@@ -4359,6 +4572,7 @@ void CScrollOverview::setClosing(bool closing_) {
     closing = closing_;
     if (closing) {
         inputFramePending = false;
+        clearDragPending();
         restoreSubmapIfActive();
         releaseInputListeners();
         restoreWorkspaceAnimationOverrides();

--- a/scrollOverview.cpp
+++ b/scrollOverview.cpp
@@ -248,11 +248,19 @@ static CBox getOverviewWindowBox(const PHLWINDOW& window, PHLMONITOR monitor, fl
     if (!window)
         return {};
 
+    return getOverviewGlobalBox({window->m_realPosition->value(), window->m_realSize->value()}, monitor, scale, viewOffset, offset, layout, round);
+}
+
+static CBox getOverviewDragWindowBox(const PHLWINDOW& window, PHLMONITOR monitor, float scale, const Vector2D& viewOffset, float offset, ScrollOverview::Config::ELayout layout,
+                                     bool round = true) {
+    if (!window)
+        return {};
+
     const auto TARGET = window->layoutTarget();
     if (window->m_group && TARGET)
         return getOverviewGlobalBox(TARGET->position(), monitor, scale, viewOffset, offset, layout, round);
 
-    return getOverviewGlobalBox({window->m_realPosition->value(), window->m_realSize->value()}, monitor, scale, viewOffset, offset, layout, round);
+    return getOverviewWindowBox(window, monitor, scale, viewOffset, offset, layout, round);
 }
 
 static CBox expandOverviewWindowHitbox(CBox box, float scale, float monitorScale) {
@@ -2072,7 +2080,7 @@ PHLWORKSPACE CScrollOverview::workspaceAtOverviewDropPoint(const Vector2D& point
                 if (!shouldShowOverviewWindow(WINDOW) || WINDOW == ignoredWindow || WINDOW->m_isFloating != floating)
                     continue;
 
-                const auto WINDOWBOX = getOverviewWindowBox(WINDOW, MONITOR, scale->value(), viewOffset->value(), WORKSPACEOFFSET, layout);
+                const auto WINDOWBOX = getOverviewDragWindowBox(WINDOW, MONITOR, scale->value(), viewOffset->value(), WORKSPACEOFFSET, layout);
                 if (!WINDOWBOX.containsPoint(point))
                     continue;
 
@@ -2213,7 +2221,7 @@ CBox CScrollOverview::draggedWindowBox(size_t workspaceIdx) const {
         return {};
 
     const auto WORKSPACE_OFFSET = workspaceOverviewOffset(workspaceIdx, activeWorkspaceIndex(), getWorkspaceRenderedPitch(MONITOR, scale->value(), layout));
-    auto       box               = getOverviewWindowBox(WINDOW, MONITOR, scale->value(), viewOffset->value(), WORKSPACE_OFFSET, layout);
+    auto       box               = getOverviewDragWindowBox(WINDOW, MONITOR, scale->value(), viewOffset->value(), WORKSPACE_OFFSET, layout);
     box.x = lastMousePosLocal.x - dragGrabOffsetLocal.x;
     box.y = lastMousePosLocal.y - dragGrabOffsetLocal.y;
 
@@ -2314,7 +2322,7 @@ void CScrollOverview::beginWindowDrag(PHLWINDOW window) {
     const auto MONITOR = pMonitor.lock();
     if (MONITOR && workspaceIdx < images.size()) {
         const auto WORKSPACEOFFSET = workspaceOverviewOffset(workspaceIdx, activeWorkspaceIndex(), getWorkspaceRenderedPitch(MONITOR, scale->value(), layout));
-        const auto WINDOWBOX       = getOverviewWindowBox(WINDOW, MONITOR, scale->value(), viewOffset->value(), WORKSPACEOFFSET, layout);
+        const auto WINDOWBOX       = getOverviewDragWindowBox(WINDOW, MONITOR, scale->value(), viewOffset->value(), WORKSPACEOFFSET, layout);
         dragGrabOffsetLocal        = dragStartMouseLocal - WINDOWBOX.pos();
         if (const auto ALGO = overviewScrollingAlgorithmForWorkspace(WINDOW->m_workspace); ALGO && ALGO->m_scrollingData && ALGO->m_scrollingData->controller)
             dragOriginalTapeTranslation = ALGO->m_scrollingData->controller->getCameraTranslation(ALGO->usableArea());

--- a/scrollOverview.cpp
+++ b/scrollOverview.cpp
@@ -768,7 +768,11 @@ static bool moveOverviewScrollingTargetNextToWindow(const SP<Layout::ITarget>& t
     if (!SRC_COL || !ANCHOR_COL)
         return false;
 
-    if (direction == "l" || direction == "r") {
+    const bool PRIMARYHORIZONTAL = ALGO->m_scrollingData->controller && ALGO->m_scrollingData->controller->isPrimaryHorizontal();
+    const bool MOVINGCOLUMN      = PRIMARYHORIZONTAL ? direction == "l" || direction == "r" : direction == "u" || direction == "d";
+    const bool STACKINGCOLUMN    = PRIMARYHORIZONTAL ? direction == "u" || direction == "d" : direction == "l" || direction == "r";
+
+    if (MOVINGCOLUMN) {
         const auto SRC_COL_WIDTH = SRC_COL->getColumnWidth();
         SRC_COL->remove(target);
 
@@ -776,7 +780,8 @@ static bool moveOverviewScrollingTargetNextToWindow(const SP<Layout::ITarget>& t
         if (ANCHOR_COL_IDX < 0)
             return false;
 
-        const int64_t INSERT_AFTER = direction == "l" ? ANCHOR_COL_IDX - 1 : ANCHOR_COL_IDX;
+        const bool    INSERT_BEFORE = direction == "l" || direction == "u";
+        const int64_t INSERT_AFTER  = INSERT_BEFORE ? ANCHOR_COL_IDX - 1 : ANCHOR_COL_IDX;
         const auto    NEW_COL      = ALGO->m_scrollingData->add(INSERT_AFTER, SRC_COL_WIDTH);
         NEW_COL->add(TDATA);
         ALGO->m_scrollingData->centerOrFitCol(NEW_COL);
@@ -786,13 +791,14 @@ static bool moveOverviewScrollingTargetNextToWindow(const SP<Layout::ITarget>& t
         return true;
     }
 
-    if (direction != "u" && direction != "d")
+    if (!STACKINGCOLUMN)
         return false;
 
     SRC_COL->remove(target);
 
-    const auto ANCHOR_IDX = ANCHOR_COL->idx(anchor->layoutTarget());
-    const int  INSERT_AFTER = direction == "u" ? sc<int>(ANCHOR_IDX) - 1 : sc<int>(ANCHOR_IDX);
+    const auto ANCHOR_IDX    = ANCHOR_COL->idx(anchor->layoutTarget());
+    const bool INSERT_BEFORE = direction == "l" || direction == "u";
+    const int  INSERT_AFTER  = INSERT_BEFORE ? sc<int>(ANCHOR_IDX) - 1 : sc<int>(ANCHOR_IDX);
     ANCHOR_COL->add(TDATA, INSERT_AFTER);
     ALGO->m_scrollingData->centerOrFitCol(ANCHOR_COL);
     ALGO->m_scrollingData->recalculate();
@@ -1768,6 +1774,9 @@ void CScrollOverview::updateWorkspaceOverflow() {
 
             const auto POS  = window->m_realPosition->value() - MONITOR->m_position;
             const auto SIZE = window->m_realSize->value();
+            // Windows hidden under a fullscreen window can get sentinel geometry like -2x-2.
+            if (SIZE.x <= 0 || SIZE.y <= 0)
+                continue;
 
             img->overflowLeft   = std::max(img->overflowLeft, std::max(0.F, sc<float>(-POS.x)));
             img->overflowRight  = std::max(img->overflowRight, std::max(0.F, sc<float>(POS.x + SIZE.x - MONITOR->m_size.x)));
@@ -1815,7 +1824,7 @@ PHLWINDOW CScrollOverview::windowAtOverviewPoint(const Vector2D& point, size_t* 
 
         const auto fullscreenWindow = wimg->pWorkspace ? getOverviewWindowToShow(wimg->pWorkspace->getFullscreenWindow()) : PHLWINDOW{};
 
-        if (shouldShowOverviewWindow(fullscreenWindow)) {
+        if (!isWorkspaceScrolling(wimg->pWorkspace) && shouldShowOverviewWindow(fullscreenWindow)) {
             for (auto it = wimg->windows.rbegin(); it != wimg->windows.rend(); ++it) {
                 const auto window = getOverviewWindowToShow(it->lock());
                 if (!shouldShowOverviewWindow(window) || !window->m_isFloating)
@@ -2592,15 +2601,16 @@ bool CScrollOverview::moveScrollingColumnSelection(bool next) {
             columns.emplace_back(column);
     }
 
-    std::ranges::sort(columns, [](const auto& a, const auto& b) {
-        const auto getColumnX = [](const auto& column) {
+    const bool PRIMARYHORIZONTAL = ALGO->m_scrollingData->controller && ALGO->m_scrollingData->controller->isPrimaryHorizontal();
+    std::ranges::sort(columns, [PRIMARYHORIZONTAL](const auto& a, const auto& b) {
+        const auto getColumnPosition = [PRIMARYHORIZONTAL](const auto& column) {
             if (!column || column->targetDatas.empty() || !column->targetDatas[0])
                 return std::numeric_limits<double>::max();
 
-            return column->targetDatas[0]->layoutBox.x;
+            return PRIMARYHORIZONTAL ? column->targetDatas[0]->layoutBox.x : column->targetDatas[0]->layoutBox.y;
         };
 
-        return getColumnX(a) < getColumnX(b);
+        return getColumnPosition(a) < getColumnPosition(b);
     });
 
     const auto CURRENTIT = std::ranges::find(columns, CURRENTCOL);
@@ -2626,6 +2636,53 @@ bool CScrollOverview::moveScrollingColumnSelection(bool next) {
     damage();
 
     return true;
+}
+
+bool CScrollOverview::moveScrollingStackSelection(bool next) {
+    if (images.empty() || viewportCurrentWorkspace >= images.size())
+        return false;
+
+    const auto& WORKSPACEIMAGE = images[viewportCurrentWorkspace];
+    if (!WORKSPACEIMAGE || !WORKSPACEIMAGE->pWorkspace)
+        return false;
+
+    const auto ALGO = overviewScrollingAlgorithmForWorkspace(WORKSPACEIMAGE->pWorkspace);
+    if (!ALGO || !ALGO->m_scrollingData || ALGO->m_scrollingData->columns.empty())
+        return false;
+
+    if (!closeOnWindow || closeOnWindow->m_workspace != WORKSPACEIMAGE->pWorkspace || !shouldShowOverviewWindow(closeOnWindow.lock()) || closeOnWindow->m_isFloating)
+        syncSelectionToViewport();
+
+    const auto CURRENT = getOverviewWindowToShow(closeOnWindow.lock());
+    if (!CURRENT || !CURRENT->layoutTarget())
+        return false;
+
+    const auto CURRENTDATA = ALGO->dataFor(CURRENT->layoutTarget());
+    const auto CURRENTCOL  = CURRENTDATA ? CURRENTDATA->column.lock() : nullptr;
+    if (!CURRENTCOL)
+        return false;
+
+    const auto CURRENTIDX = CURRENTCOL->idx(CURRENT->layoutTarget());
+    const auto TARGETIDX  = CURRENTIDX + (next ? 1 : -1);
+    if (TARGETIDX < 0 || TARGETIDX >= sc<int>(CURRENTCOL->targetDatas.size()))
+        return false;
+
+    const auto TARGETDATA = CURRENTCOL->targetDatas[TARGETIDX];
+    if (!TARGETDATA || !TARGETDATA->target)
+        return false;
+
+    for (const auto& windowRef : WORKSPACEIMAGE->windows) {
+        const auto WINDOW = getOverviewWindowToShow(windowRef.lock());
+        if (shouldShowOverviewWindow(WINDOW) && !WINDOW->m_isFloating && WINDOW->layoutTarget() == TARGETDATA->target && WINDOW->m_workspace == WORKSPACEIMAGE->pWorkspace) {
+            closeOnWindow = WINDOW;
+            rememberSelection(WINDOW);
+            syncFocusedSelection();
+            damage();
+            return true;
+        }
+    }
+
+    return false;
 }
 
 void CScrollOverview::endWindowDrag() {
@@ -2704,6 +2761,16 @@ void CScrollOverview::endWindowDrag() {
 
     const auto DROPANCHOR = dropAnchor.window;
     dropDirection         = dropAnchor.direction;
+    const bool DROPPINGONSCROLLINGCROSSAXIS =
+        DROPSCROLLINGPRIMARYHORIZONTAL ? dropDirection == "u" || dropDirection == "d" : dropDirection == "l" || dropDirection == "r";
+
+    if (DROPSCROLLINGLAYOUT && DROPANCHOR && DROPPINGONSCROLLINGCROSSAXIS && DROPANCHOR->isFullscreen()) {
+        g_pCompositor->setWindowFullscreenInternal(DROPANCHOR, FSMODE_NONE);
+        if (const auto ANCHORDATA = DROPSCROLLINGALGO->dataFor(DROPANCHOR->layoutTarget()); ANCHORDATA) {
+            if (const auto ANCHORCOL = ANCHORDATA->column.lock())
+                ANCHORCOL->setColumnWidth(1.F);
+        }
+    }
 
     if (RETILEONEND && MOVEWORKSPACE) {
         g_pCompositor->moveWindowToWorkspaceSafe(WINDOW, DROPWORKSPACE);
@@ -3076,6 +3143,23 @@ bool CScrollOverview::moveSelection(const std::string& direction) {
 
     if (!shouldMoveWorkspace)
         closeOnWindow = CURRENT;
+
+    if (!shouldMoveWorkspace) {
+        const auto ALGO = overviewScrollingAlgorithmForWorkspace(WORKSPACEIMAGE->pWorkspace);
+        if (ALGO && ALGO->m_scrollingData && ALGO->m_scrollingData->controller) {
+            const bool PRIMARYHORIZONTAL = ALGO->m_scrollingData->controller->isPrimaryHorizontal();
+            const bool MOVINGPRIMARY     = PRIMARYHORIZONTAL ? MOVINGLEFT || MOVINGRIGHT : MOVINGUP || MOVINGDOWN;
+            const bool MOVINGSTACK       = PRIMARYHORIZONTAL ? MOVINGUP || MOVINGDOWN : MOVINGLEFT || MOVINGRIGHT;
+            const bool NEXT              = MOVINGRIGHT || MOVINGDOWN;
+
+            if (MOVINGPRIMARY || MOVINGSTACK) {
+                if (MOVINGPRIMARY ? moveScrollingColumnSelection(NEXT) : moveScrollingStackSelection(NEXT))
+                    return true;
+
+                shouldMoveWorkspace = true;
+            }
+        }
+    }
 
     const auto CURRENTCENTER = shouldMoveWorkspace ? Vector2D{} : CURRENT->middle();
 

--- a/scrollOverview.cpp
+++ b/scrollOverview.cpp
@@ -245,6 +245,13 @@ static CBox getOverviewGlobalBox(CBox globalBox, PHLMONITOR monitor, float scale
 
 static CBox getOverviewWindowBox(const PHLWINDOW& window, PHLMONITOR monitor, float scale, const Vector2D& viewOffset, float offset, ScrollOverview::Config::ELayout layout,
                                  bool round = true) {
+    if (!window)
+        return {};
+
+    const auto TARGET = window->layoutTarget();
+    if (window->m_group && TARGET)
+        return getOverviewGlobalBox(TARGET->position(), monitor, scale, viewOffset, offset, layout, round);
+
     return getOverviewGlobalBox({window->m_realPosition->value(), window->m_realSize->value()}, monitor, scale, viewOffset, offset, layout, round);
 }
 
@@ -2045,10 +2052,37 @@ PHLWORKSPACE CScrollOverview::workspaceAtOverviewPoint(const Vector2D& point, si
     return nullptr;
 }
 
-PHLWORKSPACE CScrollOverview::workspaceAtOverviewDropPoint(const Vector2D& point, size_t* hoveredWorkspaceIdx) const {
+PHLWORKSPACE CScrollOverview::workspaceAtOverviewDropPoint(const Vector2D& point, size_t* hoveredWorkspaceIdx, const PHLWINDOW& ignoredWindow) const {
     const auto MONITOR = pMonitor.lock();
     if (!MONITOR)
         return nullptr;
+
+    const auto ACTIVEIDX       = activeWorkspaceIndex();
+    const auto WORKSPACEPITCH = getWorkspaceRenderedPitch(MONITOR, scale->value(), layout);
+
+    for (size_t workspaceIdx = 0; workspaceIdx < images.size(); ++workspaceIdx) {
+        const auto& wimg = images[workspaceIdx];
+        if (!wimg || !wimg->pWorkspace)
+            continue;
+
+        const auto WORKSPACEOFFSET = workspaceOverviewOffset(workspaceIdx, ACTIVEIDX, WORKSPACEPITCH);
+        for (const bool floating : {true, false}) {
+            for (auto it = wimg->windows.rbegin(); it != wimg->windows.rend(); ++it) {
+                const auto WINDOW = getOverviewWindowToShow(it->lock());
+                if (!shouldShowOverviewWindow(WINDOW) || WINDOW == ignoredWindow || WINDOW->m_isFloating != floating)
+                    continue;
+
+                const auto WINDOWBOX = getOverviewWindowBox(WINDOW, MONITOR, scale->value(), viewOffset->value(), WORKSPACEOFFSET, layout);
+                if (!WINDOWBOX.containsPoint(point))
+                    continue;
+
+                if (hoveredWorkspaceIdx)
+                    *hoveredWorkspaceIdx = workspaceIdx;
+
+                return wimg->pWorkspace;
+            }
+        }
+    }
 
     for (size_t workspaceIdx = 0; workspaceIdx < images.size(); ++workspaceIdx) {
         const auto& wimg = images[workspaceIdx];
@@ -2056,8 +2090,7 @@ PHLWORKSPACE CScrollOverview::workspaceAtOverviewDropPoint(const Vector2D& point
             continue;
 
         const auto WORKSPACEBOX = getOverviewWorkspaceUsableBox(wimg->pWorkspace, MONITOR, scale->value(), viewOffset->value(),
-                                                                workspaceOverviewOffset(workspaceIdx, activeWorkspaceIndex(), getWorkspaceRenderedPitch(MONITOR, scale->value(), layout)),
-                                                                layout);
+                                                                workspaceOverviewOffset(workspaceIdx, ACTIVEIDX, WORKSPACEPITCH), layout);
         const bool ONLAYOUTAXIS = layout == ScrollOverview::Config::ELayout::HORIZONTAL ?
             point.x >= WORKSPACEBOX.x && point.x <= WORKSPACEBOX.x + WORKSPACEBOX.width :
             point.y >= WORKSPACEBOX.y && point.y <= WORKSPACEBOX.y + WORKSPACEBOX.height;
@@ -2273,7 +2306,7 @@ void CScrollOverview::beginWindowDrag(PHLWINDOW window) {
     dragOriginalTapeTranslation  = Vector2D{};
     dragOriginalWorkspace         = WINDOW->m_workspace;
     dragOriginalBox               = TARGET->position();
-    dragOriginalVisualBox         = {WINDOW->m_realPosition->value(), WINDOW->m_realSize->value()};
+    dragOriginalVisualBox         = WINDOW->m_group ? TARGET->position() : CBox{WINDOW->m_realPosition->value(), WINDOW->m_realSize->value()};
     dragOriginalOverviewBox       = CBox{};
     dragOriginalOverviewHitbox    = CBox{};
     dragActiveWindow              = WINDOW;
@@ -2595,7 +2628,7 @@ void CScrollOverview::endWindowDrag() {
 
     const bool          RETILEONEND      = dragStartedTiled && TARGET && SPACE && ALGO;
     size_t              dropWorkspaceIdx = 0;
-    const auto          DROPWORKSPACE    = workspaceAtOverviewDropPoint(lastMousePosLocal, &dropWorkspaceIdx);
+    const auto          DROPWORKSPACE    = workspaceAtOverviewDropPoint(lastMousePosLocal, &dropWorkspaceIdx, WINDOW);
     const auto          DROPSCROLLINGALGO  = overviewScrollingAlgorithmForWorkspace(DROPWORKSPACE);
     const bool          DROPSCROLLINGLAYOUT = DROPSCROLLINGALGO != nullptr;
     const bool          DROPSCROLLINGPRIMARYHORIZONTAL =
@@ -3524,7 +3557,7 @@ void CScrollOverview::renderWorkspaceLive(PHLMONITOR monitor, size_t workspaceId
             return;
 
         size_t     dropWorkspaceIdx = 0;
-        const auto DROPWORKSPACE    = workspaceAtOverviewDropPoint(lastMousePosLocal, &dropWorkspaceIdx);
+        const auto DROPWORKSPACE    = workspaceAtOverviewDropPoint(lastMousePosLocal, &dropWorkspaceIdx, DRAGGED);
         if (DROPWORKSPACE != workspace || dropWorkspaceIdx != workspaceIdx)
             return;
 

--- a/scrollOverview.hpp
+++ b/scrollOverview.hpp
@@ -108,6 +108,7 @@ class CScrollOverview : public IOverview {
     void      endScrollingPan();
     void      focusMostVisibleScrollingWindow(const PHLWORKSPACE& workspace);
     bool      moveScrollingColumnSelection(bool next);
+    bool      moveScrollingStackSelection(bool next);
     void   forceSurfaceVisibility(SP<CWLSurfaceResource> surface);
     void   forceWindowSurfaceVisibility(PHLWINDOW window);
     void   forceWindowVisible(PHLWINDOW window);

--- a/scrollOverview.hpp
+++ b/scrollOverview.hpp
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "Config.hpp"
+#include "DropIndicator.hpp"
 #include "IOverview.hpp"
 
 class CMonitor;
@@ -87,11 +88,13 @@ class CScrollOverview : public IOverview {
     PHLWINDOW windowAtOverviewPoint(const Vector2D& point, size_t* workspaceIdx = nullptr) const;
     PHLWINDOW windowAtOverviewCursor(size_t* workspaceIdx = nullptr);
     PHLWINDOW windowAtOverviewCursorOnWorkspace(size_t workspaceIdx, const PHLWINDOW& ignoredWindow = nullptr, CBox* windowBox = nullptr) const;
+    CDropIndicator::SDropAnchor dropAnchorAtOverviewCursorOnWorkspace(size_t workspaceIdx, const PHLWINDOW& ignoredWindow = nullptr);
     PHLWORKSPACE workspaceAtOverviewPoint(const Vector2D& point, size_t* workspaceIdx = nullptr) const;
     PHLWORKSPACE workspaceAtOverviewDropPoint(const Vector2D& point, size_t* workspaceIdx = nullptr) const;
     PHLWORKSPACE workspaceAtOverviewCursor(size_t* workspaceIdx = nullptr) const;
     Vector2D  overviewPointToGlobal(size_t workspaceIdx, const Vector2D& pointLocal) const;
     CBox      draggedWindowBox(size_t workspaceIdx) const;
+    void      refreshDragOriginalOverviewBoxes();
     void      clearDragPending();
     void      beginWindowDrag(PHLWINDOW window);
     void      updateWindowDrag();
@@ -122,6 +125,7 @@ class CScrollOverview : public IOverview {
     size_t activeWorkspaceIndex() const;
     void   sendOverviewFrameCallbacks(const Time::steady_tp& now);
     bool   isVisibleRealtimePreviewWindow(const PHLWINDOW& window) const;
+    bool   hasRunningWorkspaceAnimation() const;
     bool   shouldAllowRealtimePreviewFrame() const;
     void   scheduleMinimumPreviewFrame();
     void   schedulePreviewFrameAfter(std::chrono::milliseconds delay);
@@ -174,11 +178,15 @@ class CScrollOverview : public IOverview {
     Vector2D                         dragStartMouseLocal   = Vector2D{};
     Vector2D                         dragGrabOffsetLocal   = Vector2D{};
     Vector2D                         dragOriginalFloatSize = Vector2D{};
+    Vector2D                         dragOriginalTapeTranslation = Vector2D{};
     Vector2D                         resizeStartMouseLocal = Vector2D{};
     Vector2D                         resizeLastMouseLocal  = Vector2D{};
     Vector2D                         scrollingPanLastMouseLocal = Vector2D{};
-    CBox                             dragOriginalBox        = CBox{};
-    CBox                             resizeOriginalBox      = CBox{};
+    CBox                             dragOriginalBox            = CBox{};
+    CBox                             dragOriginalVisualBox      = CBox{};
+    CBox                             dragOriginalOverviewBox    = CBox{};
+    CBox                             dragOriginalOverviewHitbox = CBox{};
+    CBox                             resizeOriginalBox          = CBox{};
     WORKSPACEID                      focusSyncedFromWorkspaceID = WORKSPACE_INVALID;
     size_t                           resizeWorkspaceIdx     = 0;
     Layout::eRectCorner              resizeCorner           = Layout::CORNER_NONE;

--- a/scrollOverview.hpp
+++ b/scrollOverview.hpp
@@ -90,7 +90,7 @@ class CScrollOverview : public IOverview {
     PHLWINDOW windowAtOverviewCursorOnWorkspace(size_t workspaceIdx, const PHLWINDOW& ignoredWindow = nullptr, CBox* windowBox = nullptr) const;
     CDropIndicator::SDropAnchor dropAnchorAtOverviewCursorOnWorkspace(size_t workspaceIdx, const PHLWINDOW& ignoredWindow = nullptr);
     PHLWORKSPACE workspaceAtOverviewPoint(const Vector2D& point, size_t* workspaceIdx = nullptr) const;
-    PHLWORKSPACE workspaceAtOverviewDropPoint(const Vector2D& point, size_t* workspaceIdx = nullptr) const;
+    PHLWORKSPACE workspaceAtOverviewDropPoint(const Vector2D& point, size_t* workspaceIdx = nullptr, const PHLWINDOW& ignoredWindow = nullptr) const;
     PHLWORKSPACE workspaceAtOverviewCursor(size_t* workspaceIdx = nullptr) const;
     Vector2D  overviewPointToGlobal(size_t workspaceIdx, const Vector2D& pointLocal) const;
     CBox      draggedWindowBox(size_t workspaceIdx) const;


### PR DESCRIPTION
This implements drop indicator (transparent box that shows the new position of the window before droppping it), as well as few minor drag and drop improvements.

Also refactors drop position to be always based on the anchor window and the direction. Only calculates anchor window if the new workspace is fully visible on the monitor, otherwise simple move to workspace is being used and drop indicator marks the whole workspace as the new target. This is consistent for drawing drop indicator awound the anchor window as well as for the drop event itself.

Preview video:
https://youtu.be/OGKucmhfSoM