### PR TITLE
fix: prevent backdrop blur clipping in HDR

### DIFF
--- a/scrollOverview.cpp
+++ b/scrollOverview.cpp
@@ -1509,13 +1509,14 @@ void CScrollOverview::updateBackdropBlurCache(PHLMONITOR monitor, int wallpaperM
 
     const auto FBSIZE     = monitor->m_pixelSize;
     const auto RENDERSIZE = monitor->m_transformedSize;
+    const auto FBFORMAT   = g_pHyprRenderer->m_renderData.currentFB->m_drmFormat;
     if (!backdropBlurFB)
         backdropBlurFB = g_pHyprRenderer->createFB("scrolloverview_backdrop_blur");
 
-    if (!backdropBlurFB || !backdropBlurFB->isAllocated() || backdropBlurFB->m_size != FBSIZE || backdropBlurFB->m_drmFormat != DRM_FORMAT_ARGB8888) {
+    if (!backdropBlurFB || !backdropBlurFB->isAllocated() || backdropBlurFB->m_size != FBSIZE || backdropBlurFB->m_drmFormat != FBFORMAT) {
         if (backdropBlurFB)
             backdropBlurFB->release();
-        if (!backdropBlurFB || !backdropBlurFB->alloc(sc<int>(FBSIZE.x), sc<int>(FBSIZE.y), DRM_FORMAT_ARGB8888))
+        if (!backdropBlurFB || !backdropBlurFB->alloc(sc<int>(FBSIZE.x), sc<int>(FBSIZE.y), FBFORMAT))
             return;
         backdropBlurDirty = true;
     }


### PR DESCRIPTION
The backdrop blur framebuffer was always allocated as ARGB8888, causing linear HDR values above 1.0 to be clipped before the blur pass.

Combined with hyprwm/Hyprland#15371, prevents blur clipping in the overview when HDR is enabled.

Before (notice clouds in blurred background are clipped)
<img width="5712" height="4284" alt="IMG_4242" src="https://github.com/user-attachments/assets/977f2566-44f9-415e-a4d7-a383015bd7bf" />

After (no clipping in clouds)
<img width="5712" height="4284" alt="IMG_4241" src="https://github.com/user-attachments/assets/79ffc46e-8726-4131-8445-73c33a75f4ce" />
