### PR TITLE
[codex] Fix Hyprland 0.56 dispatcher API

### DIFF
--- a/scrollOverview.cpp
+++ b/scrollOverview.cpp
@@ -15,6 +15,7 @@
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/config/ConfigValue.hpp>
 #include <hyprland/src/config/ConfigManager.hpp>
+#include <hyprland/src/config/lua/ConfigManager.hpp>
 #include <hyprland/src/config/shared/actions/ConfigActions.hpp>
 #include <hyprland/src/config/shared/animation/AnimationTree.hpp>
 #include <hyprland/src/config/shared/complex/ComplexDataTypes.hpp>
@@ -57,6 +58,7 @@
 #include <hyprland/src/render/decorations/CHyprGroupBarDecoration.hpp>
 #include <hyprland/src/render/decorations/DecorationPositioner.hpp>
 #include <hyprutils/utils/ScopeGuard.hpp>
+#include <hyprutils/string/Numeric.hpp>
 #undef protected
 #undef private
 #include "Config.hpp"
@@ -4828,14 +4830,8 @@ void CScrollOverview::activateSubmapIfConfigured() {
 
     previousSubmapName = g_pKeybindManager->getCurrentSubmap().name;
 
-    const auto DISPATCHER = g_pKeybindManager->m_dispatchers.find("submap");
-    if (DISPATCHER == g_pKeybindManager->m_dispatchers.end()) {
-        usesSubmapKeybinds = false;
-        return;
-    }
-
-    const auto RESULT = DISPATCHER->second(OVERVIEW_SUBMAP);
-    if (!RESULT.success) {
+    const auto RESULT = Config::Actions::setSubmap(OVERVIEW_SUBMAP);
+    if (!RESULT) {
         usesSubmapKeybinds = false;
         return;
     }
@@ -4849,9 +4845,7 @@ void CScrollOverview::restoreSubmapIfActive() {
 
     const auto CURRENT = g_pKeybindManager->getCurrentSubmap().name;
     if (CURRENT == OVERVIEW_SUBMAP) {
-        const auto DISPATCHER = g_pKeybindManager->m_dispatchers.find("submap");
-        if (DISPATCHER != g_pKeybindManager->m_dispatchers.end())
-            DISPATCHER->second(previousSubmapName.empty() ? "reset" : previousSubmapName);
+        (void)Config::Actions::setSubmap(previousSubmapName.empty() ? "reset" : previousSubmapName);
     }
 
     submapActive = false;
@@ -4872,9 +4866,9 @@ bool CScrollOverview::dispatchSubmapMouseClick(uint32_t button) {
     if (KEYBIND == g_pKeybindManager->m_keybinds.end())
         return false;
 
-    const auto DISPATCHERNAME = (*KEYBIND)->mouse ? "mouse" : (*KEYBIND)->handler;
-    const auto DISPATCHER     = g_pKeybindManager->m_dispatchers.find(DISPATCHERNAME);
-    if (DISPATCHER == g_pKeybindManager->m_dispatchers.end())
+    const auto INDEX = Hyprutils::String::strToNumber<int>((*KEYBIND)->arg);
+    const auto MGR   = Config::Lua::mgr();
+    if (!INDEX || !MGR)
         return false;
 
     const auto PREVIOUSKEYBIND = g_pKeybindManager->m_currentKeybind;
@@ -4885,8 +4879,8 @@ bool CScrollOverview::dispatchSubmapMouseClick(uint32_t button) {
     Config::Actions::state()->m_passPressed = 0;
     auto restorePassPressed = Hyprutils::Utils::CScopeGuard([PREVIOUSPASSPRESSED] { Config::Actions::state()->m_passPressed = PREVIOUSPASSPRESSED; });
 
-    DISPATCHER->second((*KEYBIND)->mouse ? "0" + (*KEYBIND)->arg : (*KEYBIND)->arg);
-    return true;
+    const auto RESULT = MGR->callLuaFnBind(*INDEX);
+    return RESULT.success;
 }
 
 void CScrollOverview::resetSwipe() {


### PR DESCRIPTION
## Summary

- replace removed `CKeybindManager::m_dispatchers` access with `Config::Actions::setSubmap`
- dispatch overview submap mouse bindings through their Lua callback references
- preserve the existing keybind and pressed-state context while invoking callbacks

## Root cause

Hyprland removed the legacy dispatcher map in `a9902ea65f461af868497c4e74fed798ade0b1b0`. ScrollOverview still accessed that map directly for submap activation, restoration, and mouse keybind dispatch, so it no longer compiled against Hyprland 0.56.

## Validation

Built the patched plugin successfully as a Nix derivation against Hyprland `0.56.0` at `62d890eaccc3fcbdc00f85fe27d611d0a8681e7a`.

Fixes #50