### PR TITLE
Multi monitor support

### DIFF
--- a/Config.cpp
+++ b/Config.cpp
@@ -48,10 +48,10 @@ SDispatcher* findDispatcher(const std::string_view name) {
     static SDispatcher registrations[] = {
         {
             .name            = "overview",
-            .argPattern      = std::regex{"^(toggle|select|on|enable|off|disable)$"},
+            .argPattern      = std::regex{R"(^(select|(toggle|on|open|enable|off|close|disable)([ \t]+(all|[^ \t"\\]+))?)$)"},
             .defaultArg      = "toggle",
             .typeArgError    = "expected an optional string argument; did you forget quotes around it?",
-            .invalidArgError = "expected one of: toggle, select, on, enable, off, disable",
+            .invalidArgError = "expected select or toggle/open/close [monitor|all] (aliases: on, enable, off, disable)",
             .luaFunction     = [](lua_State* L) { return dispatcherFactoryLua(L, "overview"); },
         },
         {

--- a/IOverview.hpp
+++ b/IOverview.hpp
@@ -1,8 +1,11 @@
 #pragma once
+#include <hyprland/src/desktop/DesktopTypes.hpp>
 #include <hyprland/src/helpers/memory/Memory.hpp>
+#include <hyprland/src/helpers/math/Math.hpp>
 #include <hyprland/src/helpers/time/Time.hpp>
 
 #include <string>
+#include <vector>
 
 class CWLSurfaceResource;
 
@@ -13,6 +16,7 @@ class IOverview {
 
     virtual void  render()           = 0;
     virtual void  damage()           = 0;
+    virtual void  requestInputFrame() = 0;
     virtual void  onDamageReported() = 0;
     virtual bool  shouldHandleSurfaceDamage(SP<CWLSurfaceResource> surface) = 0;
     virtual bool  shouldAllowSurfaceFrame(SP<CWLSurfaceResource> surface, const Time::steady_tp& now) = 0;
@@ -39,4 +43,13 @@ class IOverview {
     bool          m_isSwiping = false;
 };
 
+const std::vector<SP<IOverview>>& scrollOverviews();
+SP<IOverview>                     scrollOverviewForMonitor(PHLMONITOR monitor);
+SP<IOverview>                     scrollOverviewAt(const Vector2D& point);
+SP<IOverview>                     activeScrollOverview();
+void                              registerScrollOverview(const SP<IOverview>& overview);
+void                              unregisterScrollOverview(IOverview* overview);
+void                              clearScrollOverviews();
+
+// Current interaction/render context. The authoritative state is the registry.
 inline SP<IOverview> g_pScrollOverview;

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,6 @@ ifeq ($(CXX),g++)
 endif
 
 all:
-	$(CXX) -shared -fPIC $(EXTRA_FLAGS) main.cpp Config.cpp DropIndicator.cpp OverviewGesture.cpp OverviewPassElement.cpp OverviewRender.cpp Window.cpp scrollOverview.cpp -o scrolloverview.so -g `pkg-config --cflags pixman-1 libdrm hyprland pangocairo libinput libudev wayland-server xkbcommon lua5.4` -std=c++2b -Wno-narrowing
+	$(CXX) -shared -fPIC $(EXTRA_FLAGS) main.cpp Config.cpp DropIndicator.cpp OverviewGesture.cpp OverviewManager.cpp OverviewPassElement.cpp OverviewRender.cpp Window.cpp scrollOverview.cpp -o scrolloverview.so -g `pkg-config --cflags pixman-1 libdrm hyprland pangocairo libinput libudev wayland-server xkbcommon lua5.4` -std=c++2b -Wno-narrowing
 clean:
 	rm ./scrolloverview.so

--- a/OverviewGesture.cpp
+++ b/OverviewGesture.cpp
@@ -2,6 +2,7 @@
 
 #include "scrollOverview.hpp"
 
+#include <algorithm>
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/desktop/state/FocusState.hpp>
 #include <hyprland/src/output/Monitor.hpp>
@@ -12,19 +13,30 @@ void COverviewGesture::begin(const ITrackpadGesture::STrackpadGestureBegin& e) {
     m_lastDelta   = 0.F;
     m_firstUpdate = true;
 
-    if (!g_pScrollOverview) {
+    const auto MONITOR  = Desktop::focusState()->monitor();
+    if (!MONITOR)
+        return;
+
+    auto       overview = scrollOverviewForMonitor(MONITOR);
+
+    if (!overview) {
         if (!ensureScrollOverviewHooks())
             return;
 
-        g_pScrollOverview = makeShared<CScrollOverview>(Desktop::focusState()->monitor()->m_activeWorkspace, true);
+        overview = makeShared<CScrollOverview>(MONITOR->m_activeWorkspace, true, MONITOR);
+        registerScrollOverview(overview);
     } else {
-        g_pScrollOverview->selectHoveredWorkspace();
-        g_pScrollOverview->setClosing(true);
+        overview->selectHoveredWorkspace();
+        overview->setClosing(true);
     }
+
+    m_overview          = overview;
+    g_pScrollOverview = overview;
 }
 
 void COverviewGesture::update(const ITrackpadGesture::STrackpadGestureUpdate& e) {
-    if (!g_pScrollOverview)
+    const auto OVERVIEW = m_overview.lock();
+    if (!OVERVIEW)
         return;
 
     if (m_firstUpdate) {
@@ -37,14 +49,16 @@ void COverviewGesture::update(const ITrackpadGesture::STrackpadGestureUpdate& e)
     if (m_lastDelta <= 0.01) // plugin will crash if swipe ends at <= 0
         m_lastDelta = 0.01;
 
-    g_pScrollOverview->onSwipeUpdate(m_lastDelta);
+    OVERVIEW->onSwipeUpdate(m_lastDelta);
 }
 
 void COverviewGesture::end(const ITrackpadGesture::STrackpadGestureEnd& e) {
-    if (g_pScrollOverview)
-        g_pScrollOverview->onSwipeEnd();
+    const auto OVERVIEW = m_overview.lock();
+    if (OVERVIEW)
+        OVERVIEW->onSwipeEnd();
 
-    //re-check since onSwipeEnd can call close and de-ref g_pScrollOverview
-    if (g_pScrollOverview)
-        g_pScrollOverview->resetSwipe();
+    // Re-check the same instance since onSwipeEnd can finish its close.
+    if (std::ranges::find(scrollOverviews(), OVERVIEW) != scrollOverviews().end())
+        OVERVIEW->resetSwipe();
+    m_overview.reset();
 }

--- a/OverviewGesture.hpp
+++ b/OverviewGesture.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <hyprland/src/managers/input/trackpad/gestures/ITrackpadGesture.hpp>
+#include "IOverview.hpp"
 
 class COverviewGesture : public ITrackpadGesture {
   public:
@@ -14,4 +15,5 @@ class COverviewGesture : public ITrackpadGesture {
   private:
     float m_lastDelta   = 0.F;
     bool  m_firstUpdate = false;
+    WP<IOverview> m_overview;
 };

--- a/OverviewManager.cpp
+++ b/OverviewManager.cpp
@@ -1,0 +1,71 @@
+#include "IOverview.hpp"
+
+#include <algorithm>
+
+#include <hyprland/src/desktop/state/FocusState.hpp>
+#include <hyprland/src/managers/input/InputManager.hpp>
+#include <hyprland/src/output/Monitor.hpp>
+
+static std::vector<SP<IOverview>> g_scrollOverviews;
+
+const std::vector<SP<IOverview>>& scrollOverviews() {
+    return g_scrollOverviews;
+}
+
+SP<IOverview> scrollOverviewForMonitor(PHLMONITOR monitor) {
+    if (!monitor)
+        return {};
+
+    const auto IT = std::ranges::find_if(g_scrollOverviews, [&monitor](const auto& overview) {
+        return overview && overview->pMonitor.lock() == monitor;
+    });
+    return IT == g_scrollOverviews.end() ? SP<IOverview>{} : *IT;
+}
+
+SP<IOverview> scrollOverviewAt(const Vector2D& point) {
+    const auto IT = std::ranges::find_if(g_scrollOverviews, [&point](const auto& overview) {
+        const auto monitor = overview ? overview->pMonitor.lock() : PHLMONITOR{};
+        return monitor && monitor->logicalBox().containsPoint(point);
+    });
+    return IT == g_scrollOverviews.end() ? SP<IOverview>{} : *IT;
+}
+
+SP<IOverview> activeScrollOverview() {
+    if (g_pInputManager) {
+        if (const auto overview = scrollOverviewAt(g_pInputManager->getMouseCoordsInternal()))
+            return overview;
+    }
+
+    if (const auto monitor = Desktop::focusState()->monitor()) {
+        if (const auto overview = scrollOverviewForMonitor(monitor))
+            return overview;
+    }
+
+    if (g_pScrollOverview && std::ranges::find(g_scrollOverviews, g_pScrollOverview) != g_scrollOverviews.end())
+        return g_pScrollOverview;
+
+    return g_scrollOverviews.empty() ? SP<IOverview>{} : g_scrollOverviews.front();
+}
+
+void registerScrollOverview(const SP<IOverview>& overview) {
+    if (!overview || std::ranges::find(g_scrollOverviews, overview) != g_scrollOverviews.end())
+        return;
+
+    g_scrollOverviews.emplace_back(overview);
+    g_pScrollOverview = overview;
+}
+
+void unregisterScrollOverview(IOverview* overview) {
+    if (!overview)
+        return;
+
+    std::erase_if(g_scrollOverviews, [overview](const auto& candidate) { return candidate.get() == overview; });
+    g_pScrollOverview = activeScrollOverview();
+}
+
+void clearScrollOverviews() {
+    auto overviews = std::move(g_scrollOverviews);
+    g_scrollOverviews.clear();
+    g_pScrollOverview.reset();
+    overviews.clear();
+}

--- a/OverviewPassElement.cpp
+++ b/OverviewPassElement.cpp
@@ -93,7 +93,8 @@ CScrollOverviewPassElement::CScrollOverviewPassElement() {
 }
 
 std::vector<UP<IPassElement>> CScrollOverviewPassElement::draw() {
-    g_pScrollOverview->fullRender();
+    if (const auto overview = activeScrollOverview())
+        overview->fullRender();
     return {};
 }
 
@@ -106,17 +107,19 @@ bool CScrollOverviewPassElement::needsPrecomputeBlur() {
 }
 
 std::optional<CBox> CScrollOverviewPassElement::boundingBox() {
-    if (!g_pScrollOverview->pMonitor)
+    const auto overview = activeScrollOverview();
+    if (!overview || !overview->pMonitor)
         return std::nullopt;
 
-    return CBox{{}, g_pScrollOverview->pMonitor->m_size};
+    return CBox{{}, overview->pMonitor->m_size};
 }
 
 CRegion CScrollOverviewPassElement::opaqueRegion() {
-    if (!g_pScrollOverview->pMonitor)
+    const auto overview = activeScrollOverview();
+    if (!overview || !overview->pMonitor)
         return CRegion{};
 
-    return CBox{{}, g_pScrollOverview->pMonitor->m_size};
+    return CBox{{}, overview->pMonitor->m_size};
 }
 
 COverviewShadowPassElement::COverviewShadowPassElement(const SData& data_) : data(data_) {

--- a/README.md
+++ b/README.md
@@ -253,12 +253,19 @@ Controls the overview.
 
 | option | description |
 | --- | --- |
-| `toggle` | show the overview if hidden, hide it if visible |
+| `toggle [monitor\|all]` | toggle the active monitor, a named monitor, or every monitor |
 | `select` | select the workspace under the cursor |
-| `off` | hide the overview |
+| `close [monitor\|all]` | close every overview by default, or only the named monitor |
+| `off [monitor\|all]` | same as `close` |
 | `disable` | same as `off` |
-| `on` | show the overview |
+| `open [monitor\|all]` | open on the active monitor, a named monitor, or every monitor |
+| `on [monitor\|all]` | same as `open` |
 | `enable` | same as `on` |
+
+For example, `toggle DP-1` targets only `DP-1`, while `toggle all` opens all
+missing overviews or closes them when they are all already open. A bare
+`toggle` still targets only the active monitor, and a bare `close` closes all
+open overviews.
 
 #### `scrolloverview:navigate`
 

--- a/main.cpp
+++ b/main.cpp
@@ -11,6 +11,7 @@
 #include <hyprland/src/event/EventBus.hpp>
 #include <hyprland/src/protocols/core/Compositor.hpp>
 #include <hyprland/src/render/Renderer.hpp>
+#include <hyprland/src/state/MonitorState.hpp>
 #include <hyprland/src/managers/input/trackpad/GestureTypes.hpp>
 #include <hyprland/src/managers/input/trackpad/TrackpadGestures.hpp>
 
@@ -47,6 +48,7 @@ APICALL EXPORT std::string PLUGIN_API_VERSION() {
 
 static bool renderingOverview = false;
 static bool damageFromSurface = false;
+static PHLMONITORREF renderingOverviewMonitor;
 static bool g_scrollOverviewHooksActive = false;
 
 static void failNotif(const std::string& reason);
@@ -93,14 +95,15 @@ void disableScrollOverviewHooks() {
 }
 
 static void hkScheduleFrame(void* thisptr, Aquamarine::IOutput::scheduleFrameReason reason) {
-    if (g_pScrollOverview) {
+    const auto OVERVIEW = scrollOverviewForMonitor(sc<Monitor::CMonitor*>(thisptr)->m_self.lock());
+    if (OVERVIEW) {
         using enum Aquamarine::IOutput::scheduleFrameReason;
 
         const bool THROTTLEDREASON =
             reason == AQ_SCHEDULE_UNKNOWN || reason == AQ_SCHEDULE_CLIENT_UNKNOWN || reason == AQ_SCHEDULE_NEEDS_FRAME || reason == AQ_SCHEDULE_RENDER_MONITOR ||
             reason == AQ_SCHEDULE_DAMAGE;
 
-        if (THROTTLEDREASON && !g_pScrollOverview->blockDamageReporting && !g_pScrollOverview->shouldAllowRealtimePreviewSchedule())
+        if (THROTTLEDREASON && !OVERVIEW->blockDamageReporting && !OVERVIEW->shouldAllowRealtimePreviewSchedule())
             return;
     }
 
@@ -109,27 +112,37 @@ static void hkScheduleFrame(void* thisptr, Aquamarine::IOutput::scheduleFrameRea
 
 //
 static void hkRenderWorkspace(void* thisptr, PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& now, const CBox& geometry) {
-    if (!g_pScrollOverview || renderingOverview || g_pScrollOverview->pMonitor != pMonitor)
+    const auto OVERVIEW = scrollOverviewForMonitor(pMonitor);
+    if (!OVERVIEW || renderingOverview)
         rc<origRenderWorkspace>(g_pScrollRenderWorkspaceHook->m_original)(thisptr, pMonitor, pWorkspace, now, geometry);
     else {
         const bool PREVRENDERINGOVERVIEW = renderingOverview;
+        const auto PREVRENDERINGMONITOR  = renderingOverviewMonitor;
+        const auto PREVOVERVIEW          = g_pScrollOverview;
         renderingOverview                = true;
-        g_pScrollOverview->render();
+        renderingOverviewMonitor         = pMonitor;
+        g_pScrollOverview                = OVERVIEW;
+        OVERVIEW->render();
+        g_pScrollOverview = PREVOVERVIEW;
+        renderingOverviewMonitor = PREVRENDERINGMONITOR;
         renderingOverview = PREVRENDERINGOVERVIEW;
     }
 }
 
 static void hkDamageSurface(void* thisptr, SP<CWLSurfaceResource> surface, double x, double y, double scale) {
-    if (!g_pScrollOverview || g_pScrollOverview->blockDamageReporting || g_pScrollOverview->shouldHandleSurfaceDamage(surface)) {
+    const bool HANDLED = scrollOverviews().empty() ||
+        std::ranges::any_of(scrollOverviews(), [](const auto& overview) { return overview && overview->blockDamageReporting; }) ||
+        std::ranges::all_of(scrollOverviews(), [&surface](const auto& overview) { return !overview || overview->shouldHandleSurfaceDamage(surface); });
+    if (HANDLED) {
         const bool PREVDAMAGEFROMSURFACE = damageFromSurface;
-        damageFromSurface                = !!g_pScrollOverview;
+        damageFromSurface                = !scrollOverviews().empty();
         rc<origDamageSurface>(g_pScrollDamageSurfaceHook->m_original)(thisptr, surface, x, y, scale);
         damageFromSurface = PREVDAMAGEFROMSURFACE;
     }
 }
 
 static void hkSendFrameEventsToWorkspace(void* thisptr, PHLMONITOR monitor, PHLWORKSPACE workspace, const Time::steady_tp& now) {
-    if (g_pScrollOverview && g_pScrollOverview->pMonitor == monitor)
+    if (scrollOverviewForMonitor(monitor))
         return;
 
     rc<origSendFrameEventsToWorkspace>(g_pScrollSendFrameEventsHook->m_original)(thisptr, monitor, workspace, now);
@@ -138,7 +151,7 @@ static void hkSendFrameEventsToWorkspace(void* thisptr, PHLMONITOR monitor, PHLW
 static void hkSurfaceFrame(void* thisptr, const Time::steady_tp& now) {
     const auto SURFACE = sc<CWLSurfaceResource*>(thisptr)->m_self.lock();
 
-    if (g_pScrollOverview && !g_pScrollOverview->shouldAllowSurfaceFrame(SURFACE, now))
+    if (std::ranges::any_of(scrollOverviews(), [&SURFACE, &now](const auto& overview) { return overview && !overview->shouldAllowSurfaceFrame(SURFACE, now); }))
         return;
 
     rc<origSurfaceFrame>(g_pScrollSurfaceFrameHook->m_original)(thisptr, now);
@@ -146,96 +159,159 @@ static void hkSurfaceFrame(void* thisptr, const Time::steady_tp& now) {
 
 static void hkAddDamageA(void* thisptr, const CBox& box) {
     const auto PMONITOR = sc<Monitor::CMonitor*>( thisptr );
+    const auto OVERVIEW = scrollOverviewForMonitor(PMONITOR->m_self.lock());
 
-    if (g_pScrollOverview && g_pScrollOverview->pMonitor == PMONITOR->m_self && renderingOverview && !damageFromSurface && g_pScrollOverview->shouldSuppressRenderDamage()) {
+    if (OVERVIEW && renderingOverviewMonitor.lock() == PMONITOR->m_self.lock() && !damageFromSurface && OVERVIEW->shouldSuppressRenderDamage()) {
         return;
     }
 
-    if (!g_pScrollOverview || g_pScrollOverview->pMonitor != PMONITOR->m_self || g_pScrollOverview->blockDamageReporting || damageFromSurface) {
+    if (!OVERVIEW || OVERVIEW->blockDamageReporting || damageFromSurface) {
         rc<origAddDamageA>(g_pScrollAddDamageHookA->m_original)(thisptr, box);
         return;
     }
 
-    g_pScrollOverview->onDamageReported();
+    OVERVIEW->onDamageReported();
     rc<origAddDamageA>(g_pScrollAddDamageHookA->m_original)(thisptr, box);
 }
 
 static void hkAddDamageB(void* thisptr, const pixman_region32_t* rg) {
     const auto PMONITOR = sc<Monitor::CMonitor*>(thisptr);
+    const auto OVERVIEW = scrollOverviewForMonitor(PMONITOR->m_self.lock());
 
-    if (g_pScrollOverview && g_pScrollOverview->pMonitor == PMONITOR->m_self && renderingOverview && !damageFromSurface && g_pScrollOverview->shouldSuppressRenderDamage()) {
+    if (OVERVIEW && renderingOverviewMonitor.lock() == PMONITOR->m_self.lock() && !damageFromSurface && OVERVIEW->shouldSuppressRenderDamage()) {
         return;
     }
 
-    if (!g_pScrollOverview || g_pScrollOverview->pMonitor != PMONITOR->m_self || g_pScrollOverview->blockDamageReporting || damageFromSurface) {
+    if (!OVERVIEW || OVERVIEW->blockDamageReporting || damageFromSurface) {
         rc<origAddDamageB>(g_pScrollAddDamageHookB->m_original)(thisptr, rg);
         return;
     }
 
-    g_pScrollOverview->onDamageReported();
+    OVERVIEW->onDamageReported();
     rc<origAddDamageB>(g_pScrollAddDamageHookB->m_original)(thisptr, rg);
 }
 
+static std::pair<std::string, std::string> splitOverviewArg(const std::string& arg) {
+    const auto FIRST = arg.find_first_not_of(" \t");
+    if (FIRST == std::string::npos)
+        return {"on", ""};
+
+    const auto SEPARATOR = arg.find_first_of(" \t", FIRST);
+    if (SEPARATOR == std::string::npos)
+        return {arg.substr(FIRST), ""};
+
+    const auto TARGET = arg.find_first_not_of(" \t", SEPARATOR);
+    if (TARGET == std::string::npos)
+        return {arg.substr(FIRST, SEPARATOR - FIRST), ""};
+
+    const auto LAST = arg.find_last_not_of(" \t");
+    return {arg.substr(FIRST, SEPARATOR - FIRST), arg.substr(TARGET, LAST - TARGET + 1)};
+}
+
+static std::vector<PHLMONITOR> overviewTargetMonitors(const std::string& target) {
+    if (target == "all")
+        return State::monitorState()->monitors();
+
+    if (!target.empty()) {
+        const auto& MONITORS = State::monitorState()->monitors();
+        const auto  IT       = std::ranges::find_if(MONITORS, [&target](const auto& monitor) { return monitor && monitor->m_name == target; });
+        return IT == MONITORS.end() ? std::vector<PHLMONITOR>{} : std::vector<PHLMONITOR>{*IT};
+    }
+
+    const auto MONITOR = Desktop::focusState()->monitor();
+    return MONITOR ? std::vector<PHLMONITOR>{MONITOR} : std::vector<PHLMONITOR>{};
+}
+
+static bool openOverview(PHLMONITOR monitor) {
+    if (!monitor || scrollOverviewForMonitor(monitor))
+        return true;
+
+    if (!ensureScrollOverviewHooks())
+        return false;
+
+    const bool PREVRENDERINGOVERVIEW = renderingOverview;
+    renderingOverview                = true;
+    auto overview                    = makeShared<CScrollOverview>(monitor->m_activeWorkspace, false, monitor);
+    registerScrollOverview(overview);
+    renderingOverview = PREVRENDERINGOVERVIEW;
+    return true;
+}
+
 static SDispatchResult onOverviewDispatcher(std::string arg) {
-    if (g_pScrollOverview && g_pScrollOverview->m_isSwiping)
+    const auto [ACTION, TARGET] = splitOverviewArg(arg);
+    const auto ACTIVE           = activeScrollOverview();
+
+    if (ACTIVE && ACTIVE->m_isSwiping)
         return {.success = false, .error = "already swiping"};
 
-    if (arg == "select") {
-        if (g_pScrollOverview)
-            g_pScrollOverview->selectHoveredWorkspace();
+    if (ACTION == "select") {
+        if (ACTIVE)
+            ACTIVE->selectHoveredWorkspace();
         return {};
     }
-    if (arg == "toggle") {
-        if (g_pScrollOverview)
-            g_pScrollOverview->close();
-        else {
-            if (!ensureScrollOverviewHooks())
-                return {.success = false, .error = "failed enabling overview hooks (is other overview plugin enabled?)"};
 
-            renderingOverview = true;
-            g_pScrollOverview = makeShared<CScrollOverview>(Desktop::focusState()->monitor()->m_activeWorkspace);
-            renderingOverview = false;
+    if (ACTION == "off" || ACTION == "close" || ACTION == "disable") {
+        if (TARGET.empty() || TARGET == "all") {
+            const auto OPEN = scrollOverviews();
+            for (const auto& overview : OPEN) {
+                if (overview)
+                    overview->close();
+            }
+            return {};
+        }
+
+        const auto MONITORS = overviewTargetMonitors(TARGET);
+        if (MONITORS.empty())
+            return {.success = false, .error = "monitor not found: " + TARGET};
+        if (const auto overview = scrollOverviewForMonitor(MONITORS.front()))
+            overview->close();
+        return {};
+    }
+
+    if (ACTION != "toggle" && ACTION != "on" && ACTION != "open" && ACTION != "enable")
+        return {.success = false, .error = "invalid arg. expected toggle|open|close|select [monitor|all]"};
+
+    const auto MONITORS = overviewTargetMonitors(TARGET);
+    if (MONITORS.empty())
+        return {.success = false, .error = TARGET.empty() ? "no active monitor" : "monitor not found: " + TARGET};
+
+    const bool ALL_OPEN = std::ranges::all_of(MONITORS, [](const auto& monitor) { return !!scrollOverviewForMonitor(monitor); });
+    if (ACTION == "toggle" && ALL_OPEN) {
+        for (const auto& monitor : MONITORS) {
+            if (const auto overview = scrollOverviewForMonitor(monitor))
+                overview->close();
         }
         return {};
     }
 
-    if (arg == "off" || arg == "close" || arg == "disable") {
-        if (g_pScrollOverview)
-            g_pScrollOverview->close();
-        return {};
+    for (const auto& monitor : MONITORS) {
+        if (!openOverview(monitor))
+            return {.success = false, .error = "failed enabling overview hooks (is other overview plugin enabled?)"};
     }
-
-    if (g_pScrollOverview)
-        return {};
-
-    if (!ensureScrollOverviewHooks())
-        return {.success = false, .error = "failed enabling overview hooks (is other overview plugin enabled?)"};
-
-    renderingOverview = true;
-    g_pScrollOverview = makeShared<CScrollOverview>(Desktop::focusState()->monitor()->m_activeWorkspace);
-    renderingOverview = false;
     return {};
 }
 
 static SDispatchResult onNavigateDispatcher(std::string arg) {
-    if (!g_pScrollOverview)
+    const auto OVERVIEW = activeScrollOverview();
+    if (!OVERVIEW)
         return {};
 
     if (arg != "left" && arg != "right" && arg != "up" && arg != "down")
         return {.success = false, .error = "invalid arg. expected left|right|up|down"};
 
-    g_pScrollOverview->moveSelection(arg);
+    OVERVIEW->moveSelection(arg);
     return {};
 }
 
 static SDispatchResult onWindowDispatcher(std::string arg) {
-    if (!g_pScrollOverview)
+    const auto OVERVIEW = activeScrollOverview();
+    if (!OVERVIEW)
         return {};
 
     if (arg != "select" && arg != "close")
         return {.success = false, .error = "invalid arg. expected select|close"};
 
-    g_pScrollOverview->windowDispatcherAction(arg);
+    OVERVIEW->windowDispatcherAction(arg);
     return {};
 }
 
@@ -427,9 +503,8 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
         rc<void*>(hkAddDamageA));
 
     static auto P = Event::bus()->m_events.render.pre.listen([](PHLMONITOR monitor) {
-        if (!g_pScrollOverview || g_pScrollOverview->pMonitor != monitor)
-            return;
-        g_pScrollOverview->onPreRender();
+        if (const auto overview = scrollOverviewForMonitor(monitor))
+            overview->onPreRender();
     });
 
     ScrollOverview::Config::registerDispatcher("overview", ::onOverviewDispatcher);
@@ -445,7 +520,7 @@ APICALL EXPORT void PLUGIN_EXIT() {
     g_pHyprRenderer->m_renderPass.removeAllOfType("CScrollOverviewPassElement");
 
     g_unloading = true;
-    g_pScrollOverview.reset();
+    clearScrollOverviews();
     disableScrollOverviewHooks();
 
     if (g_pTrackpadGestures)

--- a/scrollOverview.cpp
+++ b/scrollOverview.cpp
@@ -65,17 +65,15 @@
 #include "OverviewRender.hpp"
 #include "Window.hpp"
 
-static void damageMonitor(WP<Hyprutils::Animation::CBaseAnimatedVariable> thisptr) {
-    g_pScrollOverview->damage();
-}
-
 static PHLWINDOW getOverviewFullscreenVisibilityWindow(const PHLWORKSPACE& workspace, const PHLWINDOW& fallback = {});
 static constexpr const char* OVERVIEW_SUBMAP = "scrolloverview";
+static CScrollOverview*      g_pointerGrabOverview = nullptr;
 
-static void removeOverview(WP<Hyprutils::Animation::CBaseAnimatedVariable> thisptr) {
-    const auto PMONITOR = g_pScrollOverview ? g_pScrollOverview->pMonitor.lock() : nullptr;
-    g_pScrollOverview.reset();
-    disableScrollOverviewHooks();
+static void removeOverview(CScrollOverview* overview) {
+    const auto PMONITOR = overview ? overview->pMonitor.lock() : PHLMONITOR{};
+    unregisterScrollOverview(overview);
+    if (scrollOverviews().empty())
+        disableScrollOverviewHooks();
 
     if (PMONITOR) {
         PMONITOR->recheckSolitary();
@@ -99,6 +97,10 @@ static xkb_keysym_t getOverviewKeysym(const IKeyboard::SKeyEvent& event) {
 
 static bool hasOverviewSubmap() {
     return g_pKeybindManager && std::ranges::any_of(g_pKeybindManager->m_keybinds, [](const auto& keybind) { return keybind && keybind->submap.name == OVERVIEW_SUBMAP; });
+}
+
+static bool isOverviewSubmapActive() {
+    return g_pKeybindManager && g_pKeybindManager->getCurrentSubmap().name == OVERVIEW_SUBMAP;
 }
 
 static bool isTopLayerFocused(PHLMONITOR monitor) {
@@ -292,6 +294,11 @@ static Vector2D getOverviewMousePosLocal(PHLMONITOR monitor) {
         return {};
 
     return (g_pInputManager->getMouseCoordsInternal() - monitor->m_position) * monitor->m_scale;
+}
+
+static bool isOverviewPointerOnMonitor(PHLMONITOR monitor) {
+    const auto overview = monitor ? scrollOverviewAt(g_pInputManager->getMouseCoordsInternal()) : SP<IOverview>{};
+    return overview && overview->pMonitor.lock() == monitor;
 }
 
 static Vector2D axisOffsetVector(float offset, ScrollOverview::Config::ELayout layout) {
@@ -867,6 +874,9 @@ static void moveOverviewTargetNextToWindow(const SP<Layout::ITarget>& target, co
 }
 
 CScrollOverview::~CScrollOverview() {
+    if (g_pointerGrabOverview == this)
+        g_pointerGrabOverview = nullptr;
+    transferSharedStateOwnership();
     restoreSubmapIfActive();
     if (const auto OPENGL = g_pHyprRenderer ? g_pHyprRenderer->glBackend() : WP<Render::GL::CHyprOpenGLImpl>{})
         OPENGL->makeEGLCurrent();
@@ -886,19 +896,22 @@ CScrollOverview::~CScrollOverview() {
     restoreForcedWindowVisibility();
     restoreForcedLayerVisibility();
     images.clear(); // otherwise we get a vram leak
-    Pointer::Cursor::overrideController->unsetOverride(Pointer::Cursor::CURSOR_OVERRIDE_SPECIAL_ACTION);
+    if (scrollOverviews().empty())
+        Pointer::Cursor::overrideController->unsetOverride(Pointer::Cursor::CURSOR_OVERRIDE_SPECIAL_ACTION);
     if (const auto MONITOR = pMonitor.lock())
         MONITOR->m_blurFBDirty = true;
 }
 
-CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : startedOn(startedOn_), swipe(swipe_) {
-    const auto          PMONITOR = Desktop::focusState()->monitor();
+CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_, PHLMONITOR monitor_) : startedOn(startedOn_), swipe(swipe_) {
+    const auto          PMONITOR = monitor_ ? monitor_ : (startedOn_ && startedOn_->m_monitor ? startedOn_->m_monitor.lock() : Desktop::focusState()->monitor());
     pMonitor                     = PMONITOR;
     layout                       = ScrollOverview::Config::getLayout();
+    sharedStateOwner             = scrollOverviews().empty();
     usesSubmapKeybinds           = hasOverviewSubmap();
 
     applyWorkspaceAnimationOverrides();
-    forceWorkspaceAlphaVisible();
+    if (sharedStateOwner)
+        forceWorkspaceAlphaVisible();
     applyInputConfigOverrides();
     g_pInputManager->unconstrainMouse();
     realtimePreviewTimer = wl_event_loop_add_timer(g_pCompositor->m_wlEventLoop, realtimePreviewTimerCallback, this);
@@ -932,10 +945,10 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
     Animation::mgr()->createAnimation(1.F, workspaceInsertProgress, WINDOWSMOVECONFIG, AVARDAMAGE_NONE);
     Animation::mgr()->createAnimation(1.F, workspaceInsertFadeProgress, workspaceInsertFadeConfig, AVARDAMAGE_NONE);
 
-    scale->setUpdateCallback(damageMonitor);
-    viewOffset->setUpdateCallback(damageMonitor);
-    workspaceInsertProgress->setUpdateCallback(damageMonitor);
-    workspaceInsertFadeProgress->setUpdateCallback(damageMonitor);
+    scale->setUpdateCallback([this](auto) { damage(); });
+    viewOffset->setUpdateCallback([this](auto) { damage(); });
+    workspaceInsertProgress->setUpdateCallback([this](auto) { damage(); });
+    workspaceInsertFadeProgress->setUpdateCallback([this](auto) { damage(); });
 
     if (!swipe)
         *scale = ScrollOverview::Config::getScale();
@@ -947,7 +960,8 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
     lastMousePosLocal = getOverviewMousePosLocal(pMonitor.lock());
 
     auto onMouseMove = [this](Vector2D, Event::SCallbackInfo& info) {
-        if (closing)
+        const auto INPUTOVERVIEW = scrollOverviewAt(g_pInputManager->getMouseCoordsInternal());
+        if (closing || (g_pointerGrabOverview && g_pointerGrabOverview != this) || (!g_pointerGrabOverview && INPUTOVERVIEW.get() != this))
             return;
 
         const bool     LEFT_HANDED           = ScrollOverview::Config::getLeftHanded();
@@ -1019,10 +1033,10 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
                 } else
                     beginScrollingPanAtPoint(dragStartMouseLocal);
             }
-
-            if (dragActiveWindow)
-                updateWindowDrag();
         }
+
+        if (dragActiveWindow)
+            updateWindowDrag();
 
         if (resizePointerDown && resizePendingWindow) {
             if (!resizeActiveWindow && resizeStartMouseLocal.distanceSq(lastMousePosLocal) > DRAGTHRESHOLDSQ)
@@ -1039,7 +1053,7 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
     };
 
     auto onTouchMove = [this](ITouch::SMotionEvent, Event::SCallbackInfo& info) {
-        if (closing)
+        if (closing || scrollOverviewAt(g_pInputManager->getMouseCoordsInternal()).get() != this)
             return;
 
         info.cancelled    = true;
@@ -1048,14 +1062,24 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
     };
 
     auto onMouseButton = [this](IPointer::SButtonEvent event, Event::SCallbackInfo& info) {
-        if (closing)
+        const auto INPUTOVERVIEW = scrollOverviewAt(g_pInputManager->getMouseCoordsInternal());
+        if (closing || (g_pointerGrabOverview && g_pointerGrabOverview != this) || (!g_pointerGrabOverview && INPUTOVERVIEW.get() != this))
             return;
+
+        const bool RELEASESPOINTERGRAB = event.state == WL_POINTER_BUTTON_STATE_RELEASED;
+        auto       releasePointerGrab  = Hyprutils::Utils::CScopeGuard([this, RELEASESPOINTERGRAB] {
+            if (RELEASESPOINTERGRAB && g_pointerGrabOverview == this)
+                g_pointerGrabOverview = nullptr;
+        });
 
         if (!dragPendingPrimary && !resizePointerDown && !scrollingPanPointerDown && !dragActiveWindow && !resizeActiveWindow && isPointerOnTopLayer(pMonitor.lock())) {
             submapMouseClickPending = false;
             submapMouseClickButton  = 0;
             return;
         }
+
+        if (event.state == WL_POINTER_BUTTON_STATE_PRESSED)
+            g_pointerGrabOverview = this;
 
         info.cancelled = true;
         Config::Actions::state()->m_lastMouseCode = event.button;
@@ -1077,7 +1101,7 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
             submapMouseClickButton  = 0;
         };
         const auto     beginSubmapMouseClickPending = [&](uint32_t button) {
-            if (!submapActive)
+            if (!usesSubmapKeybinds || !isOverviewSubmapActive())
                 return false;
 
             submapMouseClickPending = true;
@@ -1092,7 +1116,7 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
                 return false;
             }
 
-            return !submapActive;
+            return !usesSubmapKeybinds || !isOverviewSubmapActive();
         };
         const auto     performClickAction = [&](uint32_t button) {
             if (!shouldRunDefaultClickAction(button))
@@ -1255,7 +1279,7 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
     };
 
     auto onCursorSelect = [this](auto, Event::SCallbackInfo& info) {
-        if (closing)
+        if (closing || scrollOverviewAt(g_pInputManager->getMouseCoordsInternal()).get() != this)
             return;
 
         if (isPointerOnTopLayer(pMonitor.lock()))
@@ -1269,7 +1293,7 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
     };
 
     auto onMouseAxis = [this](IPointer::SAxisEvent e, Event::SCallbackInfo& info) {
-        if (closing)
+        if (closing || scrollOverviewAt(g_pInputManager->getMouseCoordsInternal()).get() != this)
             return;
 
         info.cancelled = true;
@@ -1379,7 +1403,7 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_) : started
     };
 
     auto onKeyboardKey = [this](IKeyboard::SKeyEvent event, Event::SCallbackInfo& info) {
-        if (closing || event.state != WL_KEYBOARD_KEY_STATE_PRESSED)
+        if (closing || event.state != WL_KEYBOARD_KEY_STATE_PRESSED || activeScrollOverview().get() != this)
             return;
 
         if (isTopLayerFocused(pMonitor.lock()))
@@ -1607,6 +1631,11 @@ size_t CScrollOverview::activeWorkspaceIndex() const {
     }
 
     return 0;
+}
+
+bool CScrollOverview::isSelectedWorkspace(const PHLWORKSPACE& workspace) const {
+    return workspace && viewportCurrentWorkspace < images.size() && images[viewportCurrentWorkspace] &&
+        images[viewportCurrentWorkspace]->pWorkspace == workspace;
 }
 
 float CScrollOverview::workspaceOverviewOffset(size_t workspaceIdx, size_t activeIdx, float workspacePitch) const {
@@ -1872,6 +1901,42 @@ PHLWINDOW CScrollOverview::windowAtOverviewCursor(size_t* hoveredWorkspaceIdx) {
     return windowAtOverviewPoint(lastMousePosLocal, hoveredWorkspaceIdx);
 }
 
+PHLWINDOW CScrollOverview::windowClosestToWorkspaceCenter(size_t workspaceIdx) const {
+    const auto MONITOR = pMonitor.lock();
+    if (!MONITOR || workspaceIdx >= images.size() || !images[workspaceIdx] || !images[workspaceIdx]->pWorkspace)
+        return {};
+
+    const auto& WORKSPACEIMAGE  = images[workspaceIdx];
+    const auto  SCALE           = scale->value();
+    const auto  WORKSPACEOFFSET =
+        workspaceOverviewOffset(workspaceIdx, activeWorkspaceIndex(), getWorkspaceRenderedPitch(MONITOR, SCALE, layout));
+    const auto WORKSPACEBOX = getOverviewWorkspaceBox(MONITOR, SCALE, viewOffset->value(), WORKSPACEOFFSET, layout);
+    const auto FULLSCREENWINDOW = getOverviewWindowToShow(Fullscreen::controller()->getFullscreenWindow(WORKSPACEIMAGE->pWorkspace));
+    const bool HASFULLSCREENPATH = !isWorkspaceScrolling(WORKSPACEIMAGE->pWorkspace) && shouldShowOverviewWindow(FULLSCREENWINDOW) &&
+        FULLSCREENWINDOW->m_workspace == WORKSPACEIMAGE->pWorkspace;
+
+    PHLWINDOW bestWindow;
+    double    bestDistance = std::numeric_limits<double>::max();
+
+    for (const auto& windowRef : WORKSPACEIMAGE->windows) {
+        const auto WINDOW = getOverviewWindowToShow(windowRef.lock());
+        if (!shouldShowOverviewWindow(WINDOW))
+            continue;
+        if (HASFULLSCREENPATH && WINDOW != FULLSCREENWINDOW && !WINDOW->m_isFloating)
+            continue;
+
+        const auto WINDOWBOX = getOverviewWindowBox(WINDOW, MONITOR, SCALE, viewOffset->value(), WORKSPACEOFFSET, layout);
+        const auto DISTANCE  = overviewBoxCenterDistanceSquared(WINDOWBOX, WORKSPACEBOX);
+        if (DISTANCE >= bestDistance)
+            continue;
+
+        bestWindow   = WINDOW;
+        bestDistance = DISTANCE;
+    }
+
+    return bestWindow;
+}
+
 PHLWINDOW CScrollOverview::windowAtOverviewCursorOnWorkspace(size_t workspaceIdx, const PHLWINDOW& ignoredWindow, CBox* windowBox) const {
     const auto MONITOR = pMonitor.lock();
     if (!MONITOR || workspaceIdx >= images.size() || !images[workspaceIdx])
@@ -1921,8 +1986,10 @@ PHLWINDOW CScrollOverview::windowAtOverviewCursorOnWorkspace(size_t workspaceIdx
     return bestWindow;
 }
 
-CDropIndicator::SDropAnchor CScrollOverview::dropAnchorAtOverviewCursorOnWorkspace(size_t workspaceIdx, const PHLWINDOW& ignoredWindow) {
+CDropIndicator::SDropAnchor CScrollOverview::dropAnchorAtOverviewCursorOnWorkspace(size_t workspaceIdx, const PHLWINDOW& ignoredWindow,
+                                                                                   CScrollOverview* dragContext) {
     CDropIndicator::SDropAnchor result;
+    const auto                  DRAGCONTEXT = dragContext ? dragContext : this;
 
     const auto MONITOR = pMonitor.lock();
     if (!MONITOR || workspaceIdx >= images.size() || !images[workspaceIdx])
@@ -1940,7 +2007,7 @@ CDropIndicator::SDropAnchor CScrollOverview::dropAnchorAtOverviewCursorOnWorkspa
     if (!overviewBoxFullyVisibleOnMonitor(WORKSPACEBOX, MONITOR))
         return result;
 
-    if (!dragStartedTiled)
+    if (!DRAGCONTEXT->dragStartedTiled)
         return result;
 
     const auto boxesForWindow = [&](const PHLWINDOW& window) {
@@ -1968,19 +2035,21 @@ CDropIndicator::SDropAnchor CScrollOverview::dropAnchorAtOverviewCursorOnWorkspa
         return LOCAL_Y < box.height / 2.F ? std::string{"u"} : std::string{"d"};
     };
 
-    refreshDragOriginalOverviewBoxes();
+    DRAGCONTEXT->refreshDragOriginalOverviewBoxes();
 
-    const auto ORIGINALHITBOX = dragOriginalOverviewHitbox.empty() ? dragOriginalOverviewBox : dragOriginalOverviewHitbox;
-    if (ignoredWindow && !dragOriginalOverviewBox.empty() && ORIGINALHITBOX.containsPoint(lastMousePosLocal) && WORKSPACE == dragOriginalWorkspace.lock()) {
-        setAnchor(result, ignoredWindow, dragOriginalOverviewBox);
+    const auto ORIGINALHITBOX =
+        DRAGCONTEXT->dragOriginalOverviewHitbox.empty() ? DRAGCONTEXT->dragOriginalOverviewBox : DRAGCONTEXT->dragOriginalOverviewHitbox;
+    if (ignoredWindow && !DRAGCONTEXT->dragOriginalOverviewBox.empty() && ORIGINALHITBOX.containsPoint(lastMousePosLocal) &&
+        WORKSPACE == DRAGCONTEXT->dragOriginalWorkspace.lock()) {
+        setAnchor(result, ignoredWindow, DRAGCONTEXT->dragOriginalOverviewBox);
         return result;
     }
 
     const auto ALGO = overviewScrollingAlgorithmForWorkspace(WORKSPACE);
     const bool PRIMARYHORIZONTAL = ALGO && ALGO->m_scrollingData && ALGO->m_scrollingData->controller && ALGO->m_scrollingData->controller->isPrimaryHorizontal();
     const auto pointsToOriginalStackSlot = [&](const PHLWINDOW& anchor, const std::string& direction) {
-        if (!ALGO || !ALGO->m_scrollingData || !ALGO->m_scrollingData->controller || !ignoredWindow || dragOriginalOverviewBox.empty() || WORKSPACE != dragOriginalWorkspace.lock() ||
-            !anchor || !anchor->layoutTarget() || !ignoredWindow->layoutTarget())
+        if (!ALGO || !ALGO->m_scrollingData || !ALGO->m_scrollingData->controller || !ignoredWindow || DRAGCONTEXT->dragOriginalOverviewBox.empty() ||
+            WORKSPACE != DRAGCONTEXT->dragOriginalWorkspace.lock() || !anchor || !anchor->layoutTarget() || !ignoredWindow->layoutTarget())
             return false;
 
         const auto ANCHORDATA  = ALGO->dataFor(anchor->layoutTarget());
@@ -2005,8 +2074,8 @@ CDropIndicator::SDropAnchor CScrollOverview::dropAnchorAtOverviewCursorOnWorkspa
         return (ANCHORPREVIOUS && direction == "r") || (!ANCHORPREVIOUS && direction == "l");
     };
     const auto pointsToOriginalColumnSlot = [&](const PHLWINDOW& anchor, const std::string& direction) {
-        if (!ALGO || !ALGO->m_scrollingData || !ALGO->m_scrollingData->controller || !ignoredWindow || dragOriginalOverviewBox.empty() || WORKSPACE != dragOriginalWorkspace.lock() ||
-            !anchor || !anchor->layoutTarget() || !ignoredWindow->layoutTarget())
+        if (!ALGO || !ALGO->m_scrollingData || !ALGO->m_scrollingData->controller || !ignoredWindow || DRAGCONTEXT->dragOriginalOverviewBox.empty() ||
+            WORKSPACE != DRAGCONTEXT->dragOriginalWorkspace.lock() || !anchor || !anchor->layoutTarget() || !ignoredWindow->layoutTarget())
             return false;
 
         const auto ANCHORDATA   = ALGO->dataFor(anchor->layoutTarget());
@@ -2032,7 +2101,7 @@ CDropIndicator::SDropAnchor CScrollOverview::dropAnchorAtOverviewCursorOnWorkspa
     };
     const auto normalizeOriginalSlotAnchor = [&]() {
         if (pointsToOriginalStackSlot(result.window, result.direction) || pointsToOriginalColumnSlot(result.window, result.direction))
-            setAnchor(result, ignoredWindow, dragOriginalOverviewBox);
+            setAnchor(result, ignoredWindow, DRAGCONTEXT->dragOriginalOverviewBox);
     };
 
     float bestDistanceSq = std::numeric_limits<float>::max();
@@ -2304,6 +2373,44 @@ CBox CScrollOverview::draggedWindowBox(size_t workspaceIdx) const {
     return box;
 }
 
+CBox CScrollOverview::draggedWindowBoxFor(PHLWINDOW window, size_t workspaceIdx, const Vector2D& pointLocal, const Vector2D& grabRatio) const {
+    window             = getOverviewWindowToShow(window);
+    const auto MONITOR = pMonitor.lock();
+    if (!window || !MONITOR || workspaceIdx >= images.size())
+        return {};
+
+    const auto WORKSPACEOFFSET = workspaceOverviewOffset(workspaceIdx, activeWorkspaceIndex(), getWorkspaceRenderedPitch(MONITOR, scale->value(), layout));
+    auto       box             = getOverviewDragWindowBox(window, MONITOR, scale->value(), viewOffset->value(), WORKSPACEOFFSET, layout);
+    box.x = pointLocal.x - box.width * std::clamp(grabRatio.x, 0.0, 1.0);
+    box.y = pointLocal.y - box.height * std::clamp(grabRatio.y, 0.0, 1.0);
+    return box;
+}
+
+CBox CScrollOverview::draggedWindowGlobalBox() const {
+    const auto WINDOW  = getOverviewWindowToShow(dragActiveWindow.lock());
+    const auto MONITOR = pMonitor.lock();
+    if (!WINDOW || !MONITOR)
+        return {};
+
+    const auto WORKSPACEIDX = dragWorkspaceIndex(WINDOW);
+    if (WORKSPACEIDX >= images.size())
+        return {};
+
+    const auto WORKSPACEOFFSET =
+        workspaceOverviewOffset(WORKSPACEIDX, activeWorkspaceIndex(), getWorkspaceRenderedPitch(MONITOR, scale->value(), layout));
+    const auto SOURCEBOX =
+        getOverviewDragWindowBox(WINDOW, MONITOR, scale->value(), viewOffset->value(), WORKSPACEOFFSET, layout, false);
+    const auto GLOBALSIZE = SOURCEBOX.size() * (1.F / std::max(MONITOR->m_scale, 0.01F));
+    const auto CURSOR     = g_pInputManager->getMouseCoordsInternal();
+
+    return {
+        CURSOR.x - GLOBALSIZE.x * std::clamp(dragGrabRatio.x, 0.0, 1.0),
+        CURSOR.y - GLOBALSIZE.y * std::clamp(dragGrabRatio.y, 0.0, 1.0),
+        GLOBALSIZE.x,
+        GLOBALSIZE.y,
+    };
+}
+
 void CScrollOverview::refreshDragOriginalOverviewBoxes() {
     const auto WINDOW    = getOverviewWindowToShow(dragActiveWindow.lock());
     const auto WORKSPACE = dragOriginalWorkspace.lock();
@@ -2400,11 +2507,17 @@ void CScrollOverview::beginWindowDrag(PHLWINDOW window) {
         const auto WORKSPACEOFFSET = workspaceOverviewOffset(workspaceIdx, activeWorkspaceIndex(), getWorkspaceRenderedPitch(MONITOR, scale->value(), layout));
         const auto WINDOWBOX       = getOverviewDragWindowBox(WINDOW, MONITOR, scale->value(), viewOffset->value(), WORKSPACEOFFSET, layout);
         dragGrabOffsetLocal        = dragStartMouseLocal - WINDOWBOX.pos();
+        dragGrabRatio              = Vector2D{
+            WINDOWBOX.width > 0.0 ? dragGrabOffsetLocal.x / WINDOWBOX.width : 0.5,
+            WINDOWBOX.height > 0.0 ? dragGrabOffsetLocal.y / WINDOWBOX.height : 0.5,
+        };
         if (const auto ALGO = overviewScrollingAlgorithmForWorkspace(WINDOW->m_workspace); ALGO && ALGO->m_scrollingData && ALGO->m_scrollingData->controller)
             dragOriginalTapeTranslation = ALGO->m_scrollingData->controller->getCameraTranslation(ALGO->usableArea());
         refreshDragOriginalOverviewBoxes();
-    } else
+    } else {
         dragGrabOffsetLocal = Vector2D{};
+        dragGrabRatio       = Vector2D{0.5, 0.5};
+    }
 
     updateWindowDrag();
 }
@@ -2438,7 +2551,13 @@ void CScrollOverview::updateWindowDrag() {
     if (!dragActiveWindow)
         return;
 
-    damage();
+    for (const auto& overview : scrollOverviews()) {
+        if (!overview)
+            continue;
+
+        overview->requestInputFrame();
+        overview->damage();
+    }
 }
 
 void CScrollOverview::updateWindowResize() {
@@ -2483,6 +2602,7 @@ void CScrollOverview::clearDragPending() {
     dragOriginalFloatSize       = Vector2D{};
     dragOriginalTapeTranslation = Vector2D{};
     dragGrabOffsetLocal         = Vector2D{};
+    dragGrabRatio               = Vector2D{0.5, 0.5};
     dragOriginalBox             = CBox{};
     dragOriginalVisualBox       = CBox{};
     dragOriginalOverviewBox     = CBox{};
@@ -2758,9 +2878,14 @@ void CScrollOverview::endWindowDrag() {
     const auto SPACE  = TARGET ? TARGET->space() : nullptr;
     const auto ALGO   = SPACE ? SPACE->algorithm() : nullptr;
 
-    const bool          RETILEONEND      = dragStartedTiled && TARGET && SPACE && ALGO;
-    size_t              dropWorkspaceIdx = 0;
-    const auto          DROPWORKSPACE    = workspaceAtOverviewDropPoint(lastMousePosLocal, &dropWorkspaceIdx, WINDOW);
+    const auto          targetOverview = scrollOverviewAt(g_pInputManager->getMouseCoordsInternal());
+    auto*               dropOverview   = targetOverview ? dynamic_cast<CScrollOverview*>(targetOverview.get()) : nullptr;
+
+    const auto          DROPMONITOR       = dropOverview ? dropOverview->pMonitor.lock() : PHLMONITOR{};
+    const auto          DROPPOINTLOCAL    = getOverviewMousePosLocal(DROPMONITOR);
+    const bool          RETILEONEND       = dragStartedTiled && TARGET && SPACE && ALGO;
+    size_t              dropWorkspaceIdx  = 0;
+    const auto          DROPWORKSPACE     = dropOverview ? dropOverview->workspaceAtOverviewDropPoint(DROPPOINTLOCAL, &dropWorkspaceIdx, WINDOW) : PHLWORKSPACE{};
     const auto          DROPSCROLLINGALGO  = overviewScrollingAlgorithmForWorkspace(DROPWORKSPACE);
     const bool          DROPSCROLLINGLAYOUT = DROPSCROLLINGALGO != nullptr;
     const bool          DROPSCROLLINGPRIMARYHORIZONTAL =
@@ -2768,7 +2893,7 @@ void CScrollOverview::endWindowDrag() {
         DROPSCROLLINGALGO->m_scrollingData->controller->isPrimaryHorizontal();
     const auto          ORIGINALWORKSPACE = dragOriginalWorkspace.lock();
     const bool          MOVEWORKSPACE    = DROPWORKSPACE && DROPWORKSPACE != ORIGINALWORKSPACE;
-    const auto          DRAGBOX          = DROPWORKSPACE ? draggedWindowBox(dropWorkspaceIdx) : CBox{};
+    const auto          DRAGBOX          = DROPWORKSPACE ? dropOverview->draggedWindowBoxFor(WINDOW, dropWorkspaceIdx, DROPPOINTLOCAL, dragGrabRatio) : CBox{};
     int                 dropSide         = 0;
     CDropIndicator::SDropAnchor dropAnchor;
     std::string         dropDirection;
@@ -2776,6 +2901,8 @@ void CScrollOverview::endWindowDrag() {
     if (!DROPWORKSPACE) {
         clearDragPending();
         damage();
+        if (dropOverview && dropOverview != this)
+            dropOverview->damage();
         return;
     }
 
@@ -2783,13 +2910,16 @@ void CScrollOverview::endWindowDrag() {
     const bool RESTORESOURCEFULLSCREENFOCUS = WINDOW && WINDOW->m_isFloating && MOVEWORKSPACE && shouldShowOverviewWindow(SOURCEFULLSCREENWINDOW) &&
         SOURCEFULLSCREENWINDOW != WINDOW && SOURCEFULLSCREENWINDOW->m_workspace == ORIGINALWORKSPACE && Fullscreen::controller()->isFullscreen(SOURCEFULLSCREENWINDOW);
 
-    const bool DROPSIDEHORIZONTAL = layout != ScrollOverview::Config::ELayout::HORIZONTAL || DROPSCROLLINGPRIMARYHORIZONTAL;
+    const bool DROPSIDEHORIZONTAL = dropOverview->layout != ScrollOverview::Config::ELayout::HORIZONTAL || DROPSCROLLINGPRIMARYHORIZONTAL;
 
     const auto MONITOR = pMonitor.lock();
     const auto ACTIVEWORKSPACEBEFOREDROP = MONITOR ? MONITOR->m_activeWorkspace : PHLWORKSPACE{};
+    const auto DROPACTIVEWORKSPACEBEFOREDROP = DROPMONITOR ? DROPMONITOR->m_activeWorkspace : PHLWORKSPACE{};
     const auto RESTOREACTIVEWORKSPACE = [&]() {
         if (MONITOR && ACTIVEWORKSPACEBEFOREDROP && MONITOR->m_activeWorkspace != ACTIVEWORKSPACEBEFOREDROP)
             MONITOR->changeWorkspace(ACTIVEWORKSPACEBEFOREDROP, false, true, true);
+        if (DROPMONITOR && DROPMONITOR != MONITOR && DROPACTIVEWORKSPACEBEFOREDROP && DROPMONITOR->m_activeWorkspace != DROPACTIVEWORKSPACEBEFOREDROP)
+            DROPMONITOR->changeWorkspace(DROPACTIVEWORKSPACEBEFOREDROP, false, true, true);
     };
     const auto RESTOREVIEWPORTWORKSPACE = [&]() {
         if (!ACTIVEWORKSPACEBEFOREDROP)
@@ -2804,27 +2934,31 @@ void CScrollOverview::endWindowDrag() {
     };
 
     bool       dropWorkspaceFullyVisible = false;
-    if (MONITOR) {
+    if (DROPMONITOR) {
         const auto WORKSPACEBOX =
-            getOverviewWorkspaceBox(MONITOR, scale->value(), viewOffset->value(),
-                                    workspaceOverviewOffset(dropWorkspaceIdx, activeWorkspaceIndex(), getWorkspaceRenderedPitch(MONITOR, scale->value(), layout)), layout);
-        dropWorkspaceFullyVisible = overviewBoxFullyVisibleOnMonitor(WORKSPACEBOX, MONITOR);
+            getOverviewWorkspaceBox(DROPMONITOR, dropOverview->scale->value(), dropOverview->viewOffset->value(),
+                                    dropOverview->workspaceOverviewOffset(dropWorkspaceIdx, dropOverview->activeWorkspaceIndex(),
+                                                                         getWorkspaceRenderedPitch(DROPMONITOR, dropOverview->scale->value(), dropOverview->layout)),
+                                    dropOverview->layout);
+        dropWorkspaceFullyVisible = overviewBoxFullyVisibleOnMonitor(WORKSPACEBOX, DROPMONITOR);
 
         if (DROPSIDEHORIZONTAL) {
-            if (lastMousePosLocal.x < WORKSPACEBOX.x)
+            if (DROPPOINTLOCAL.x < WORKSPACEBOX.x)
                 dropSide = -1;
-            else if (lastMousePosLocal.x > WORKSPACEBOX.x + WORKSPACEBOX.width)
+            else if (DROPPOINTLOCAL.x > WORKSPACEBOX.x + WORKSPACEBOX.width)
                 dropSide = 1;
         } else {
-            if (lastMousePosLocal.y < WORKSPACEBOX.y)
+            if (DROPPOINTLOCAL.y < WORKSPACEBOX.y)
                 dropSide = -1;
-            else if (lastMousePosLocal.y > WORKSPACEBOX.y + WORKSPACEBOX.height)
+            else if (DROPPOINTLOCAL.y > WORKSPACEBOX.y + WORKSPACEBOX.height)
                 dropSide = 1;
         }
     }
 
-    if (DROPWORKSPACE)
-        dropAnchor = dropAnchorAtOverviewCursorOnWorkspace(dropWorkspaceIdx, WINDOW);
+    if (DROPWORKSPACE) {
+        dropOverview->lastMousePosLocal = DROPPOINTLOCAL;
+        dropAnchor                      = dropOverview->dropAnchorAtOverviewCursorOnWorkspace(dropWorkspaceIdx, WINDOW, this);
+    }
 
     const auto DROPANCHOR = dropAnchor.window;
     dropDirection         = dropAnchor.direction;
@@ -2879,11 +3013,11 @@ void CScrollOverview::endWindowDrag() {
         Desktop::globalWindowController()->moveWindowToWorkspace(WINDOW, DROPWORKSPACE);
         RESTOREACTIVEWORKSPACE();
         if (TARGET) {
-            const auto GLOBALSIZE = DRAGBOX.size() * (1.F / (std::max(scale->value(), 0.01F) * std::max(MONITOR ? MONITOR->m_scale : 1.F, 0.01F)));
-            auto       GLOBALBOX  = dropWorkspaceFullyVisible ? CBox{overviewPointToGlobal(dropWorkspaceIdx, DRAGBOX.pos()), GLOBALSIZE} :
-                                                                centerBoxInWorkspace(CBox{Vector2D{}, GLOBALSIZE}, DROPWORKSPACE, MONITOR);
+            const auto GLOBALSIZE = DRAGBOX.size() * (1.F / (std::max(dropOverview->scale->value(), 0.01F) * std::max(DROPMONITOR ? DROPMONITOR->m_scale : 1.F, 0.01F)));
+            auto       GLOBALBOX  = dropWorkspaceFullyVisible ? CBox{dropOverview->overviewPointToGlobal(dropWorkspaceIdx, DRAGBOX.pos()), GLOBALSIZE} :
+                                                                centerBoxInWorkspace(CBox{Vector2D{}, GLOBALSIZE}, DROPWORKSPACE, DROPMONITOR);
             if (dropWorkspaceFullyVisible)
-                GLOBALBOX = clampBoxToWorkspace(GLOBALBOX, DROPWORKSPACE, MONITOR, WINDOW->getRealBorderSize());
+                GLOBALBOX = clampBoxToWorkspace(GLOBALBOX, DROPWORKSPACE, DROPMONITOR, WINDOW->getRealBorderSize());
 
             TARGET->setPositionGlobal(GLOBALBOX);
             TARGET->warpPositionSize();
@@ -2919,15 +3053,19 @@ void CScrollOverview::endWindowDrag() {
         }
     }
 
-    if (DROPWORKSPACE && MONITOR && DROPWORKSPACE == MONITOR->m_activeWorkspace) {
+    if (DROPWORKSPACE && DROPMONITOR && DROPWORKSPACE == DROPMONITOR->m_activeWorkspace) {
         const auto FULLSCREENWINDOW = getOverviewWindowToShow(Fullscreen::controller()->getFullscreenWindow(DROPWORKSPACE));
         if (shouldShowOverviewWindow(FULLSCREENWINDOW) && FULLSCREENWINDOW->m_workspace == DROPWORKSPACE)
-            emitFullscreenVisibilityState(FULLSCREENWINDOW, true);
+            dropOverview->emitFullscreenVisibilityState(FULLSCREENWINDOW, true);
     }
 
     clearDragPending();
     rebuildPending = true;
     damage();
+    if (dropOverview != this) {
+        dropOverview->rebuildPending = true;
+        dropOverview->damage();
+    }
 }
 
 void CScrollOverview::endWindowResize() {
@@ -2983,16 +3121,8 @@ void CScrollOverview::moveViewportWorkspace(bool up) {
             closeOnWindow = rememberedWindow;
     }
 
-    if (!closeOnWindow) {
-        for (const auto& windowRef : TARGETWORKSPACEIMAGE->windows) {
-            const auto window = getOverviewWindowToShow(windowRef.lock());
-            if (!shouldShowOverviewWindow(window))
-                continue;
-
-            closeOnWindow = window;
-            break;
-        }
-    }
+    if (!closeOnWindow)
+        closeOnWindow = windowClosestToWorkspaceCenter(viewportCurrentWorkspace);
 
     if (pMonitor && pMonitor->m_activeWorkspace != TARGETWORKSPACEIMAGE->pWorkspace)
         pMonitor->changeWorkspace(TARGETWORKSPACEIMAGE->pWorkspace, false, true, true);
@@ -3177,11 +3307,7 @@ void CScrollOverview::syncSelectionToViewport() {
         return;
     }
 
-    for (const auto& windowRef : WSPACE->windows) {
-        const auto window = getOverviewWindowToShow(windowRef.lock());
-        if (!shouldShowOverviewWindow(window))
-            continue;
-
+    if (const auto window = windowClosestToWorkspaceCenter(viewportCurrentWorkspace)) {
         closeOnWindow = window;
         rememberSelection(window);
         syncFocusedSelection();
@@ -3516,7 +3642,7 @@ void CScrollOverview::restoreForcedLayerVisibility() {
 }
 
 void CScrollOverview::applyWorkspaceAnimationOverrides() {
-    if (workspaceAnimationsOverridden)
+    if (!sharedStateOwner || workspaceAnimationsOverridden)
         return;
 
     savedWorkspaceAnimationConfigs.clear();
@@ -3590,7 +3716,7 @@ void CScrollOverview::forceWorkspaceWindowsDecoRecalc(const PHLWORKSPACE& worksp
 }
 
 void CScrollOverview::applyInputConfigOverrides() {
-    if (inputConfigOverridden)
+    if (!sharedStateOwner || inputConfigOverridden)
         return;
 
     previousNoWarps                    = ScrollOverview::Config::getValue<int>("cursor:no_warps");
@@ -3618,6 +3744,47 @@ void CScrollOverview::restoreInputConfigOverrides() {
     ScrollOverview::Config::setValue("input:follow_mouse", previousFollowMouse);
 
     inputConfigOverridden = false;
+}
+
+void CScrollOverview::transferSharedStateOwnership() {
+    if (!sharedStateOwner)
+        return;
+
+    CScrollOverview* successor = nullptr;
+    for (const auto& overview : scrollOverviews()) {
+        auto* candidate = overview ? dynamic_cast<CScrollOverview*>(overview.get()) : nullptr;
+        if (candidate && candidate != this && !candidate->closing) {
+            successor = candidate;
+            break;
+        }
+    }
+
+    if (!successor)
+        return;
+
+    successor->sharedStateOwner = true;
+
+    successor->savedWorkspaceAnimationConfigs = std::move(savedWorkspaceAnimationConfigs);
+    successor->workspaceAnimationsOverridden  = workspaceAnimationsOverridden;
+    savedWorkspaceAnimationConfigs.clear();
+    workspaceAnimationsOverridden = false;
+
+    successor->previousNoWarps                    = previousNoWarps;
+    successor->previousWarpOnChangeWorkspace      = previousWarpOnChangeWorkspace;
+    successor->previousWarpOnToggleSpecial        = previousWarpOnToggleSpecial;
+    successor->previousWarpBackAfterNonMouseInput = previousWarpBackAfterNonMouseInput;
+    successor->previousFollowMouse                = previousFollowMouse;
+    successor->inputConfigOverridden              = inputConfigOverridden;
+    inputConfigOverridden = false;
+
+    successor->usesSubmapKeybinds   = usesSubmapKeybinds;
+    successor->submapActive         = submapActive;
+    successor->previousSubmapName   = std::move(previousSubmapName);
+    if (successor->usesSubmapKeybinds)
+        successor->keyboardKeyHook.reset();
+    usesSubmapKeybinds = false;
+    submapActive       = false;
+    sharedStateOwner   = false;
 }
 
 void CScrollOverview::emitFullscreenVisibilityState(PHLWINDOW window, bool hideFullscreen) {
@@ -3744,8 +3911,12 @@ void CScrollOverview::renderWorkspaceLive(PHLMONITOR monitor, size_t workspaceId
         if (hasRunningWorkspaceAnimation())
             return;
 
-        const auto DRAGGED = getOverviewWindowToShow(dragActiveWindow.lock());
+        auto*      dragContext = g_pointerGrabOverview && g_pointerGrabOverview->dragActiveWindow ? g_pointerGrabOverview : this;
+        const auto DRAGGED     = getOverviewWindowToShow(dragContext->dragActiveWindow.lock());
         if (!DRAGGED)
+            return;
+
+        if (!isOverviewPointerOnMonitor(monitor))
             return;
 
         size_t     dropWorkspaceIdx = 0;
@@ -3753,7 +3924,7 @@ void CScrollOverview::renderWorkspaceLive(PHLMONITOR monitor, size_t workspaceId
         if (DROPWORKSPACE != workspace || dropWorkspaceIdx != workspaceIdx)
             return;
 
-        const auto ANCHOR = dropAnchorAtOverviewCursorOnWorkspace(workspaceIdx, DRAGGED);
+        const auto ANCHOR      = dropAnchorAtOverviewCursorOnWorkspace(workspaceIdx, DRAGGED, dragContext);
         const auto WORKSPACEBOX = getOverviewWorkspaceBox(monitor, renderScale, viewOffset->value(), WORKSPACEOFFSET, layout);
 
         CDropIndicator::renderDropIndicator({
@@ -3798,20 +3969,22 @@ void CScrollOverview::renderWorkspaceLive(PHLMONITOR monitor, size_t workspaceId
 }
 
 void CScrollOverview::renderDraggedWindow(PHLMONITOR monitor, size_t activeIdx, float workspacePitch, float renderScale, const Time::steady_tp& now) {
-    const auto WINDOW = getOverviewWindowToShow(dragActiveWindow.lock());
+    auto*      dragOwner = g_pointerGrabOverview && g_pointerGrabOverview->dragActiveWindow ? g_pointerGrabOverview : this;
+    const auto WINDOW    = getOverviewWindowToShow(dragOwner->dragActiveWindow.lock());
     if (!shouldShowOverviewWindow(WINDOW) || !WINDOW->m_workspace)
         return;
 
-    const auto workspaceIdx = dragWorkspaceIndex(WINDOW);
-    if (workspaceIdx >= images.size())
+    const auto GLOBALBOX  = dragOwner->draggedWindowGlobalBox();
+    const auto MONITORBOX = monitor ? monitor->logicalBox() : CBox{};
+    if (GLOBALBOX.empty() || MONITORBOX.empty() || GLOBALBOX.intersection(MONITORBOX).empty())
         return;
 
-    const auto windowBox = draggedWindowBox(workspaceIdx);
+    const auto windowBox = CBox{
+        (GLOBALBOX.pos() - monitor->m_position) * monitor->m_scale,
+        GLOBALBOX.size() * monitor->m_scale,
+    };
 
-    if (!overviewBoxIntersectsMonitor(windowBox, monitor))
-        return;
-
-    renderWindowLive(monitor, WINDOW, windowBox, renderScale, now, nullptr, true);
+    renderWindowLive(monitor, WINDOW, windowBox, dragOwner->scale->value(), now, nullptr, true);
 }
 
 bool CScrollOverview::hasVisiblePrecomputedBlurWindow(PHLMONITOR monitor, size_t activeIdx, float workspacePitch, float renderScale) const {
@@ -4050,6 +4223,11 @@ bool CScrollOverview::shouldAllowRealtimePreviewSchedule() {
         return true;
     }
 
+    if (selectedWorkspaceFramePending) {
+        selectedWorkspaceFramePending = false;
+        return true;
+    }
+
     if (closing)
         return true;
 
@@ -4198,28 +4376,32 @@ void CScrollOverview::sendOverviewFrameCallbacks(const Time::steady_tp& now) {
     const auto SCALE     = scale->value();
     const auto PITCH     = getWorkspaceRenderedPitch(MONITOR, SCALE, layout);
     const auto DRAGGED   = getOverviewWindowToShow(dragActiveWindow.lock());
-    const bool CANFRAMEWINDOWS = closing || shouldAllowRealtimePreviewFrame();
-    bool       sentWindowFrame = false;
+    const bool CANFRAMETHROTTLEDWINDOWS = closing || shouldAllowRealtimePreviewFrame();
+    bool       sentThrottledWindowFrame = false;
 
     const bool PREVSENDINGFRAMECALLBACKS = sendingOverviewFrameCallbacks;
-    sendingOverviewFrameCallbacks        = CANFRAMEWINDOWS;
+    sendingOverviewFrameCallbacks        = CANFRAMETHROTTLEDWINDOWS;
     auto resetSendingFrameCallbacks      = Hyprutils::Utils::CScopeGuard([this, PREVSENDINGFRAMECALLBACKS] { sendingOverviewFrameCallbacks = PREVSENDINGFRAMECALLBACKS; });
 
-    const auto frameWindow = [&](const PHLWINDOW& window, float workspaceOffset) {
-        if (!shouldShowOverviewWindow(window) || window == DRAGGED)
+    const auto frameWindow = [&](const PHLWINDOW& window, float workspaceOffset, bool realtime) {
+        if (!shouldShowOverviewWindow(window))
             return;
 
-        const auto WINDOWBOX = getOverviewWindowBox(window, MONITOR, SCALE, viewOffset->value(), workspaceOffset, layout);
-        if (!overviewBoxIntersectsMonitor(WINDOWBOX, MONITOR))
-            return;
+        const bool ISDRAGGED = window == DRAGGED;
+        if (!ISDRAGGED) {
+            const auto WINDOWBOX = getOverviewWindowBox(window, MONITOR, SCALE, viewOffset->value(), workspaceOffset, layout);
+            if (!overviewBoxIntersectsMonitor(WINDOWBOX, MONITOR))
+                return;
+        }
 
-        if (!CANFRAMEWINDOWS) {
+        if (!realtime && !ISDRAGGED && !CANFRAMETHROTTLEDWINDOWS) {
             scheduleRealtimePreviewFrame();
             return;
         }
 
         surfaceTreePresent(window->wlSurface() ? window->wlSurface()->resource() : nullptr, MONITOR, now);
-        sentWindowFrame = true;
+        if (!realtime && !ISDRAGGED)
+            sentThrottledWindowFrame = true;
     };
 
     for (const auto& windowRef : pinnedFloatingWindows) {
@@ -4227,13 +4409,13 @@ void CScrollOverview::sendOverviewFrameCallbacks(const Time::steady_tp& now) {
         if (!shouldShowPinnedFloatingOverviewWindow(window) || window->m_monitor != MONITOR)
             continue;
 
-        if (!CANFRAMEWINDOWS) {
+        if (!CANFRAMETHROTTLEDWINDOWS) {
             scheduleRealtimePreviewFrame();
             continue;
         }
 
         surfaceTreePresent(window->wlSurface() ? window->wlSurface()->resource() : nullptr, MONITOR, now);
-        sentWindowFrame = true;
+        sentThrottledWindowFrame = true;
     }
 
     for (size_t workspaceIdx = 0; workspaceIdx < images.size(); ++workspaceIdx) {
@@ -4248,25 +4430,26 @@ void CScrollOverview::sendOverviewFrameCallbacks(const Time::steady_tp& now) {
             continue;
 
         const auto workspace = workspaceImage->pWorkspace;
+        const bool REALTIME  = isSelectedWorkspace(workspace);
         if (!isWorkspaceScrolling(workspace)) {
             const auto fullscreenWindow = getOverviewWindowToShow(Fullscreen::controller()->getFullscreenWindow(workspace));
             if (shouldShowOverviewWindow(fullscreenWindow) && fullscreenWindow->m_workspace == workspace) {
-                frameWindow(fullscreenWindow, WORKSPACEOFFSET);
+                frameWindow(fullscreenWindow, WORKSPACEOFFSET, REALTIME);
                 for (const auto& windowRef : workspaceImage->windows) {
                     const auto window = getOverviewWindowToShow(windowRef.lock());
                     if (window && window->m_isFloating)
-                        frameWindow(window, WORKSPACEOFFSET);
+                        frameWindow(window, WORKSPACEOFFSET, REALTIME);
                 }
                 continue;
             }
         }
 
         for (const auto& windowRef : workspaceImage->windows) {
-            frameWindow(getOverviewWindowToShow(windowRef.lock()), WORKSPACEOFFSET);
+            frameWindow(getOverviewWindowToShow(windowRef.lock()), WORKSPACEOFFSET, REALTIME);
         }
     }
 
-    if (sentWindowFrame)
+    if (sentThrottledWindowFrame)
         lastRealtimePreviewFrame = now;
 
     realtimePreviewFrameQueued = false;
@@ -4310,6 +4493,10 @@ bool CScrollOverview::shouldAllowSurfaceFrame(SP<CWLSurfaceResource> surface, co
         return true;
 
     auto window = getOverviewWindowToShow(windowOwner);
+    if (g_pointerGrabOverview && g_pointerGrabOverview->dragActiveWindow &&
+        window == getOverviewWindowToShow(g_pointerGrabOverview->dragActiveWindow.lock()))
+        return true;
+
     if (!window || window->m_monitor != MONITOR)
         return true;
 
@@ -4343,6 +4530,9 @@ bool CScrollOverview::shouldAllowSurfaceFrame(SP<CWLSurfaceResource> surface, co
         const auto WINDOWBOX        = getOverviewWindowBox(window, MONITOR, SCALE, viewOffset->value(), WORKSPACEOFFSET, layout);
         if (!overviewBoxIntersectsMonitor(WINDOWBOX, MONITOR))
             return false;
+
+        if (isSelectedWorkspace(workspaceImage->pWorkspace))
+            return true;
 
         if (sendingOverviewFrameCallbacks)
             return true;
@@ -4396,6 +4586,14 @@ bool CScrollOverview::shouldHandleSurfaceDamage(SP<CWLSurfaceResource> surface) 
         return true;
 
     auto window = getOverviewWindowToShow(windowOwner);
+    if (g_pointerGrabOverview && g_pointerGrabOverview->dragActiveWindow &&
+        window == getOverviewWindowToShow(g_pointerGrabOverview->dragActiveWindow.lock())) {
+        const auto DRAGBOX = g_pointerGrabOverview->draggedWindowGlobalBox();
+        if (!DRAGBOX.empty() && !DRAGBOX.intersection(MONITOR->logicalBox()).empty())
+            damage();
+        return true;
+    }
+
     if (shouldShowPinnedFloatingOverviewWindow(window)) {
         if (window->m_monitor != MONITOR)
             return true;
@@ -4433,6 +4631,11 @@ bool CScrollOverview::shouldHandleSurfaceDamage(SP<CWLSurfaceResource> surface) 
         if (!overviewBoxIntersectsMonitor(WINDOWBOX, MONITOR))
             return false;
 
+        if (isSelectedWorkspace(workspaceImage->pWorkspace)) {
+            selectedWorkspaceFramePending = true;
+            return true;
+        }
+
         if (!realtimePreviewFrameQueued && shouldAllowRealtimePreviewFrame())
             return true;
 
@@ -4464,7 +4667,7 @@ void CScrollOverview::close() {
             damage();
         }
 
-        scale->setCallbackOnEnd(removeOverview);
+        scale->setCallbackOnEnd([this](auto) { removeOverview(this); });
     };
 
     if (!closeOnWindow && (!SELECTEDWORKSPACE || SELECTEDWORKSPACE == pMonitor->m_activeWorkspace)) {
@@ -4705,6 +4908,9 @@ void CScrollOverview::render() {
     if (!MONITOR)
         return;
 
+    if (g_pointerGrabOverview && g_pointerGrabOverview != this && g_pointerGrabOverview->dragActiveWindow && isOverviewPointerOnMonitor(MONITOR))
+        lastMousePosLocal = getOverviewMousePosLocal(MONITOR);
+
     const bool PREVBLOCKSURFACEFEEDBACK       = g_pHyprRenderer->m_bBlockSurfaceFeedback;
     g_pHyprRenderer->m_bBlockSurfaceFeedback  = true;
     auto restoreSurfaceFeedback               = Hyprutils::Utils::CScopeGuard([PREVBLOCKSURFACEFEEDBACK] { g_pHyprRenderer->m_bBlockSurfaceFeedback = PREVBLOCKSURFACEFEEDBACK; });
@@ -4799,6 +5005,7 @@ static Vector2D hyprlerp(const Vector2D& from, const Vector2D& to, const float p
 void CScrollOverview::setClosing(bool closing_) {
     closing = closing_;
     if (closing) {
+        transferSharedStateOwnership();
         inputFramePending = false;
         clearDragPending();
         restoreSubmapIfActive();
@@ -4823,7 +5030,7 @@ void CScrollOverview::releaseInputListeners() {
 }
 
 void CScrollOverview::activateSubmapIfConfigured() {
-    if (!usesSubmapKeybinds || !g_pKeybindManager)
+    if (!sharedStateOwner || !usesSubmapKeybinds || !g_pKeybindManager)
         return;
 
     previousSubmapName = g_pKeybindManager->getCurrentSubmap().name;
@@ -4858,7 +5065,7 @@ void CScrollOverview::restoreSubmapIfActive() {
 }
 
 bool CScrollOverview::dispatchSubmapMouseClick(uint32_t button) {
-    if (!submapActive || !g_pKeybindManager || !g_pInputManager)
+    if (!usesSubmapKeybinds || !isOverviewSubmapActive() || !g_pKeybindManager || !g_pInputManager)
         return false;
 
     const auto KEYNAME = "mouse:" + std::to_string(button);

--- a/scrollOverview.cpp
+++ b/scrollOverview.cpp
@@ -961,6 +961,12 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_, PHLMONITO
 
     auto onMouseMove = [this](Vector2D, Event::SCallbackInfo& info) {
         const auto INPUTOVERVIEW = scrollOverviewAt(g_pInputManager->getMouseCoordsInternal());
+        if (INPUTOVERVIEW) {
+            const auto INPUTMONITOR = INPUTOVERVIEW->pMonitor.lock();
+            if (INPUTMONITOR && INPUTMONITOR != Desktop::focusState()->monitor())
+                Desktop::focusState()->rawMonitorFocus(INPUTMONITOR);
+        }
+
         if (closing || (g_pointerGrabOverview && g_pointerGrabOverview != this) || (!g_pointerGrabOverview && INPUTOVERVIEW.get() != this))
             return;
 
@@ -3323,6 +3329,9 @@ void CScrollOverview::syncFocusedSelection() {
         return;
 
     closeOnWindow = window;
+
+    if (activeScrollOverview().get() != this)
+        return;
 
     if (Desktop::focusState()->window() == window && window->m_workspace == pMonitor->m_activeWorkspace)
         return;

--- a/scrollOverview.hpp
+++ b/scrollOverview.hpp
@@ -25,11 +25,12 @@ struct wl_event_source;
 
 class CScrollOverview : public IOverview {
   public:
-    CScrollOverview(PHLWORKSPACE startedOn_, bool swipe = false);
+    CScrollOverview(PHLWORKSPACE startedOn_, bool swipe = false, PHLMONITOR monitor = {});
     ~CScrollOverview() override;
 
     void         render() override;
     void         damage() override;
+    void         requestInputFrame() override;
     void         markBlurDirty();
     void         markBackdropBlurDirty();
     void         onDamageReported() override;
@@ -77,6 +78,7 @@ class CScrollOverview : public IOverview {
     bool   scrollStepAllowed(uint32_t timeMs);
     bool   selectOverviewWindow(PHLWINDOW window, size_t workspaceIdx, bool syncFocus = false);
     bool   selectWindowAtOverviewCursor(bool syncFocus = false);
+    PHLWINDOW windowClosestToWorkspaceCenter(size_t workspaceIdx) const;
     void   rememberSelection(PHLWINDOW window);
     void   syncSelectionToViewport();
     void   syncFocusedSelection();
@@ -89,12 +91,15 @@ class CScrollOverview : public IOverview {
     PHLWINDOW windowAtOverviewPoint(const Vector2D& point, size_t* workspaceIdx = nullptr) const;
     PHLWINDOW windowAtOverviewCursor(size_t* workspaceIdx = nullptr);
     PHLWINDOW windowAtOverviewCursorOnWorkspace(size_t workspaceIdx, const PHLWINDOW& ignoredWindow = nullptr, CBox* windowBox = nullptr) const;
-    CDropIndicator::SDropAnchor dropAnchorAtOverviewCursorOnWorkspace(size_t workspaceIdx, const PHLWINDOW& ignoredWindow = nullptr);
+    CDropIndicator::SDropAnchor dropAnchorAtOverviewCursorOnWorkspace(size_t workspaceIdx, const PHLWINDOW& ignoredWindow = nullptr,
+                                                                      CScrollOverview* dragContext = nullptr);
     PHLWORKSPACE workspaceAtOverviewPoint(const Vector2D& point, size_t* workspaceIdx = nullptr) const;
     PHLWORKSPACE workspaceAtOverviewDropPoint(const Vector2D& point, size_t* workspaceIdx = nullptr, const PHLWINDOW& draggedWindow = nullptr) const;
     PHLWORKSPACE workspaceAtOverviewCursor(size_t* workspaceIdx = nullptr) const;
     Vector2D  overviewPointToGlobal(size_t workspaceIdx, const Vector2D& pointLocal) const;
     CBox      draggedWindowBox(size_t workspaceIdx) const;
+    CBox      draggedWindowBoxFor(PHLWINDOW window, size_t workspaceIdx, const Vector2D& pointLocal, const Vector2D& grabRatio) const;
+    CBox      draggedWindowGlobalBox() const;
     void      refreshDragOriginalOverviewBoxes();
     void      clearDragPending();
     void      beginWindowDrag(PHLWINDOW window);
@@ -124,7 +129,9 @@ class CScrollOverview : public IOverview {
     void   emitFullscreenVisibilityState(PHLWINDOW window, bool hideFullscreen);
     void   applyInputConfigOverrides();
     void   restoreInputConfigOverrides();
+    void   transferSharedStateOwnership();
     size_t activeWorkspaceIndex() const;
+    bool   isSelectedWorkspace(const PHLWORKSPACE& workspace) const;
     void   sendOverviewFrameCallbacks(const Time::steady_tp& now);
     bool   isVisibleRealtimePreviewWindow(const PHLWINDOW& window) const;
     bool   hasRunningWorkspaceAnimation() const;
@@ -136,7 +143,6 @@ class CScrollOverview : public IOverview {
     void   activateSubmapIfConfigured();
     void   restoreSubmapIfActive();
     bool   dispatchSubmapMouseClick(uint32_t button);
-    void   requestInputFrame();
     static int realtimePreviewTimerCallback(void* data);
 
     size_t viewportCurrentWorkspace = 0;
@@ -179,6 +185,7 @@ class CScrollOverview : public IOverview {
 
     Vector2D                         dragStartMouseLocal   = Vector2D{};
     Vector2D                         dragGrabOffsetLocal   = Vector2D{};
+    Vector2D                         dragGrabRatio         = Vector2D{0.5, 0.5};
     Vector2D                         dragOriginalFloatSize = Vector2D{};
     Vector2D                         dragOriginalTapeTranslation = Vector2D{};
     Vector2D                         resizeStartMouseLocal = Vector2D{};
@@ -201,6 +208,7 @@ class CScrollOverview : public IOverview {
     bool                             inputConfigOverridden = false;
     bool                             realtimePreviewTimerArmed = false;
     bool                             realtimePreviewFrameQueued = false;
+    bool                             selectedWorkspaceFramePending = false;
     bool                             inputFramePending = false;
     bool                             sendingOverviewFrameCallbacks = false;
     bool                             usesSubmapKeybinds = false;
@@ -245,6 +253,7 @@ class CScrollOverview : public IOverview {
     };
     std::vector<SWorkspaceAnimationConfig> savedWorkspaceAnimationConfigs;
     bool                                   workspaceAnimationsOverridden = false;
+    bool                                   sharedStateOwner = false;
 
     PHLWORKSPACE                     startedOn;
 


### PR DESCRIPTION
Multi monitor support. 
By default toggle and open dispatchers only open the overview on a single monitor, however it is now possible to open it on all monitors with `hl.plugin.scrolloverview.overview("toggle all")` or open on any number of specific monitors, for example this will open the overview on two specific monitors only:
```
hl.plugin.scrolloverview.overview("toggle DP-1")
hl.plugin.scrolloverview.overview("toggle HDMI-A-2")
```

Dragging windows between the monitors also works, but they both need the overview opened.

Closes #33 