### PR TITLE
fix: allow modifier + wheel binds in overview submaps

### DIFF
--- a/scrollOverview.cpp
+++ b/scrollOverview.cpp
@@ -1362,6 +1362,10 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_, PHLMONITO
         if (closing || scrollOverviewAt(g_pInputManager->getMouseCoordsInternal()).get() != this)
             return;
 
+        const auto MODS = g_pInputManager->getModsFromAllKBs() & ~(HL_MODIFIER_CAPS | HL_MODIFIER_MOD2);
+        if (usesSubmapKeybinds && isOverviewSubmapActive() && MODS != 0)
+            return;
+
         info.cancelled = true;
 
         const auto ACTION = e.axis == WL_POINTER_AXIS_HORIZONTAL_SCROLL ? ScrollOverview::Config::getHorizontalScrollAction(layout) :


### PR DESCRIPTION
Current main always consumes mouse-axis events while the overview is active, preventing modifier-wheel keybinds from running in a scrolloverview submap.

This is a focused alternative to one of the changes in [#36](https://github.com/yayuuu/hyprland-scroll-overview/pull/36). It lets modified mouse axis events reach Hyprland only when a custom scrolloverview submap is active.

Caps Lock and Num Lock are ignored when detecting modifiers, preserving normal overview scrolling. Unmodified scrolling and configurations without a custom overview submap are unchanged.

Meson build succeeds against Hyprland 0.56.1.
Confirmed 'Super + Wheel' can now be binded to a seperate action than 'wheel'.