### PR TITLE
fix: allow reopening during close animation

### DIFF
--- a/IOverview.hpp
+++ b/IOverview.hpp
@@ -31,6 +31,8 @@ class IOverview {
     virtual void  onSwipeEnd()                = 0;
 
     virtual void  close()                  = 0;
+    virtual bool  isClosing() const        = 0;
+    virtual void  reopen()                 = 0;
     virtual void  selectHoveredWorkspace() = 0;
     virtual bool  moveSelection(const std::string& direction) = 0;
     virtual bool  windowDispatcherAction(const std::string& action) = 0;

--- a/main.cpp
+++ b/main.cpp
@@ -287,8 +287,12 @@ static SDispatchResult onOverviewDispatcher(std::string arg) {
     const bool ALL_OPEN = std::ranges::all_of(MONITORS, [](const auto& monitor) { return !!scrollOverviewForMonitor(monitor); });
     if (ACTION == "toggle" && ALL_OPEN) {
         for (const auto& monitor : MONITORS) {
-            if (const auto overview = scrollOverviewForMonitor(monitor))
-                overview->close();
+            if (const auto overview = scrollOverviewForMonitor(monitor)) {
+                if (overview->isClosing())
+                    overview->reopen();
+                else
+                    overview->close();
+            }
         }
         return {};
     }

--- a/scrollOverview.cpp
+++ b/scrollOverview.cpp
@@ -4910,6 +4910,23 @@ void CScrollOverview::close() {
     finishClose(FINALWORKSPACE, FINALWINDOW);
 }
 
+bool CScrollOverview::isClosing() const {
+    return closing;
+}
+
+void CScrollOverview::reopen() {
+    if (!closing)
+        return;
+
+    scale->setCallbackOnEnd({});
+    closeApplied = false;
+    setClosing(false);
+    activateSubmapIfConfigured();
+    emitFullscreenVisibilityState(Desktop::focusState()->window(), true);
+    *scale = ScrollOverview::Config::getScale();
+    damage();
+}
+
 void CScrollOverview::onPreRender() {
     if (pMonitor)
         pMonitor->m_solitaryClient.reset();
@@ -5140,9 +5157,11 @@ void CScrollOverview::setClosing(bool closing_) {
     if (closing) {
         transferSharedStateOwnership();
         inputFramePending = false;
+        if (scrollingPanPointerDown)
+            endScrollingPan();
+        releaseTopLayerPointerButtons(Time::millis(Time::steadyNow()));
         clearDragPending();
         restoreSubmapIfActive();
-        releaseInputListeners();
     } else
         applyWorkspaceAnimationOverrides();
 }

--- a/scrollOverview.hpp
+++ b/scrollOverview.hpp
@@ -48,6 +48,8 @@ class CScrollOverview : public IOverview {
 
     // close without a selection
     void         close() override;
+    bool         isClosing() const override;
+    void         reopen() override;
     void         selectHoveredWorkspace() override;
     bool         moveSelection(const std::string& direction) override;
     bool         windowDispatcherAction(const std::string& action) override;


### PR DESCRIPTION
## Summary

- treat `toggle` during a close animation as a reopen request
- cancel the pending teardown callback and reverse the scale animation
- retain input listeners while closing so interaction can be restored
- restore the configured overview submap on reopen

## Root cause

An overview remains registered until its close animation fully settles. A second toggle therefore finds that closing instance and calls `close()` again, which is ignored by the existing double-close guard. This creates a visible lockout after the overview appears closed, particularly with spring animations.

## Impact

Users can toggle the overview open again immediately while preserving both opening and closing animations.

## Validation

- built successfully with `make -j$(nproc)` against current `main`
- tested locally with repeated `SUPER+TAB` toggles and a spring-based `windowsMove` animation