### PR TITLE
feat: optionally hide empty workspaces

### DIFF
--- a/Config.cpp
+++ b/Config.cpp
@@ -272,6 +272,8 @@ static void registerConfigValues() {
     HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE,
                                   makeShared<CIntValue>("plugin:scrolloverview:workspace_gap", "gap between overview workspaces", 0, SIntValueOptions{.min = 0}));
     HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE,
+                                  makeShared<CBoolValue>("plugin:scrolloverview:hide_empty_workspaces", "hide non-persistent empty workspace cards", false));
+    HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE,
                                   makeShared<CStringValue>("plugin:scrolloverview:layout", "overview layout", Hyprlang::STRING{"vertical"}));
     HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE,
                                   makeShared<CIntValue>("plugin:scrolloverview:input:scroll_event_delay", "minimum delay (ms) between discrete scroll steps (wheel workspace nav and trackpad focus stepping)", 200, SIntValueOptions{.min = 0}));

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ plugin {
         gesture_distance = 300 # how far is the "max" for the gesture
         scale = 0.5 # preferred overview scale
         workspace_gap = 100
+        hide_empty_workspaces = false
         layout = vertical # vertical or horizontal
         wallpaper = 0 # 0: global only, 1: per-workspace only, 2: both
         blur = false # blur only the main overview wallpaper
@@ -61,6 +62,7 @@ hl.config({
             gesture_distance = 300, -- how far is the "max" for the gesture
             scale = 0.5, -- preferred overview scale
             workspace_gap = 100,
+            hide_empty_workspaces = false,
             layout = "vertical", -- vertical or horizontal
             wallpaper = 0, -- 0: global only, 1: per-workspace only, 2: both
             blur = false, -- blur only the main overview wallpaper
@@ -86,6 +88,7 @@ In Lua, `shadow.color` must be an integer color value or a gradient (refer to th
 | gesture_distance | number | how far is the max for the gesture                                     | `200`   |
 | scale            | float  | overview scale, [0.1 - 0.9]                                            | `0.5`   |
 | workspace_gap    | number | gap between visible workspaces in the overview, in pixels              | `0`     |
+| hide_empty_workspaces | bool | hide non-persistent empty workspaces, except the active workspace   | `false` |
 | layout           | string | overview layout: `vertical` or `horizontal`                           | `vertical` |
 | wallpaper        | int    | wallpaper mode: `0` global only, `1` per-workspace only, `2` both      | `0`     |
 | blur             | bool   | blur the main overview wallpaper without blurring workspace wallpapers | `false` |

--- a/scrollOverview.cpp
+++ b/scrollOverview.cpp
@@ -1821,6 +1821,10 @@ void CScrollOverview::rebuildWorkspaceImages() {
         if (WORKSPACE == REMOVEDWORKSPACE)
             continue;
 
+        if (ScrollOverview::Config::getValue<bool>("plugin:scrolloverview:hide_empty_workspaces") && WORKSPACE != pMonitor->m_activeWorkspace &&
+            !WORKSPACE->isPersistent() && WORKSPACE->getWindowCount() == 0)
+            continue;
+
         images.emplace_back(makeShared<SWorkspaceImage>(WORKSPACE));
     }
 


### PR DESCRIPTION
## Summary

- add a `hide_empty_workspaces` configuration option
- omit empty, non-persistent workspaces from the overview when enabled
- always retain the active workspace
- document Hyprlang and Lua configuration

## Motivation

[Split-monitor workspace ](https://github.com/zjeffer/split-monitor-workspaces) setups can create assigned but unused workspaces. Showing all of them adds empty cards to the overview and makes window navigation less useful. The option defaults to `false`, preserving existing behavior.

## Validation

- built successfully with `make -j$(nproc)` against current `main`
- tested locally with split-monitor workspaces and Lua configuration