### PR TITLE
修复 new-release 对最新 Hyprland 渲染器 API 的兼容性

### DIFF
--- a/scrollOverview.cpp
+++ b/scrollOverview.cpp
@@ -1583,13 +1583,6 @@ void CScrollOverview::updateBackdropBlurCache(PHLMONITOR monitor, int wallpaperM
         auto bindBackdrop = g_pHyprRenderer->bindTempFB(backdropBlurFB);
         g_pHyprRenderer->draw(CClearPassElement::SClearData{CHyprColor{0.F, 0.F, 0.F, 0.F}}, fullDamage);
 
-        const auto SAVEDTRANSFORM = BLURREDTEX->m_transform;
-        BLURREDTEX->m_transform   = Math::wlTransformToHyprutils(Math::invertTransform(monitor->m_transform));
-        auto restoreTransform     = Hyprutils::Utils::CScopeGuard([BLURREDTEX, SAVEDTRANSFORM] { BLURREDTEX->m_transform = SAVEDTRANSFORM; });
-
-        g_pHyprRenderer->pushMonitorTransformEnabled(true);
-        auto restoreMonitorTransform = Hyprutils::Utils::CScopeGuard([] { g_pHyprRenderer->popMonitorTransformEnabled(); });
-
         g_pHyprRenderer->draw(
             CTexPassElement::SRenderData{
                 .tex    = BLURREDTEX,
@@ -1611,11 +1604,10 @@ void CScrollOverview::renderBackdropBlurCache(PHLMONITOR monitor) {
 
     g_pHyprRenderer->draw(
         CTexPassElement::SRenderData{
-            .tex      = TEX,
-            .box      = CBox{0, 0, monitor->m_transformedSize.x, monitor->m_transformedSize.y},
-            .a        = 1.F,
-            .damage   = fullDamage,
-            .flipEndFrame = true,
+            .tex    = TEX,
+            .box    = CBox{0, 0, monitor->m_transformedSize.x, monitor->m_transformedSize.y},
+            .a      = 1.F,
+            .damage = fullDamage,
         },
         fullDamage);
 }


### PR DESCRIPTION
## 背景

Hyprland 渲染器已改为始终使用 normal transform，并移除了以下 API：

- `pushMonitorTransformEnabled`
- `popMonitorTransformEnabled`
- `flipEndFrame`

插件的 `new-release` 分支仍在调用这些 API，因此无法针对其锁定的 Hyprland 构建。IPC Socket2 和 dispatcher/Lua API 迁移已经包含在 `new-release` 中，本 PR 现在仅补充缺失的 renderer 迁移。

## 修改

- 移除 backdrop blur cache 的手动 texture transform
- 移除 monitor transform 栈
- 移除已不存在的 `flipEndFrame`

## 验证

基于 `new-release` (`498a45d45cd86825b80ce0b14bc4820d27bc4326`) 完成：

- `git diff --check`
- `nix build .# --no-link`

构建使用该分支 `flake.lock` 固定的 Hyprland `924a35735ebadd67c8a078042060fe7e6ba7e060`，成功完成，仅保留现有编译警告。