### PR TITLE
build: use mkHyprlandPlugin in flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,24 +26,18 @@
                 system,
                 ...
             }: let
-                hl = hyprland.packages.${system}.hyprland;
+                hyprlandPackage = hyprland.packages.${system}.hyprland;
             in {
-                packages.scrolloverview = pkgs.stdenv.mkDerivation {
-                    pname = "hyprland-scroll-overview";
+                packages.scrolloverview = pkgs.hyprlandPlugins.mkHyprlandPlugin {
+                    hyprland = hyprlandPackage;
+                    pluginName = "scrolloverview";
                     version = self.shortRev or self.dirtyShortRev or "unknown";
                     src = ./.;
 
-                    inherit (hl) buildInputs;
-                    nativeBuildInputs =
-                        hl.nativeBuildInputs
-                        ++ [
-                            hl
-                            pkgs.gcc14
-                            pkgs.pkg-config
-                            pkgs.lua5_4
-                        ];
+                    buildInputs = [pkgs.lua5_4];
 
                     enableParallelBuilding = true;
+                    dontUseCmakeConfigure = true;
 
                     buildPhase = ''
                         runHook preBuild
@@ -55,9 +49,16 @@
                     installPhase = ''
                         runHook preInstall
                         mkdir -p "$out/lib"
-                        cp libscrolloverview.so "$out/lib/libscrolloverview.so"
+                        mv scrolloverview.so "$out/lib/libscrolloverview.so"
                         runHook postInstall
                     '';
+
+                    meta = {
+                        description = "Scrollable workspace overview plugin for Hyprland";
+                        homepage = "https://github.com/yayuuu/hyprland-scroll-overview";
+                        license = pkgs.lib.licenses.bsd3;
+                        platforms = pkgs.lib.platforms.linux;
+                    };
                 };
 
                 packages.default = config.packages.scrolloverview;


### PR DESCRIPTION
Replace the manual `stdenv.mkDerivation` packaging with the Hyprland-specific `pkgs.hyprlandPlugins.mkHyprlandPlugin` helper.

This:
- explicitly builds against the Hyprland package pinned by this flake
- removes copied Hyprland build inputs and the hard-coded GCC version
- installs the plugin under the standard `lib/libscrolloverview.so` path
- preserves the existing Makefile build and development shell

The existing `flake.lock` is intentionally unchanged so Hyprland keeps its matching nixpkgs dependency set.

Tested with:
```console
nix build .# --no-link
```