### PR TITLE
fix: adapt new-release to Hyprland window presentation API

### DIFF
--- a/DropIndicator.cpp
+++ b/DropIndicator.cpp
@@ -5,7 +5,8 @@
 #include <sstream>
 
 #define private public
-#include <hyprland/src/desktop/view/Window.hpp>
+#include <hyprland/src/desktop/view/window/Window.hpp>
+#include <hyprland/src/desktop/view/window/WindowPresentation.hpp>
 #include <hyprland/src/layout/algorithm/Algorithm.hpp>
 #include <hyprland/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.hpp>
 #include <hyprland/src/render/Renderer.hpp>
@@ -103,7 +104,7 @@ static CBox clipScrollingIndicatorBox(CBox box, const CDropIndicator::SRenderPar
 }
 
 static int indicatorRounding(const CDropIndicator::SRenderParams& params) {
-    const float ROUNDING = params.anchor.window ? params.anchor.window->rounding() : ScrollOverview::Config::getValue<int>("decoration:rounding");
+    const float ROUNDING = params.anchor.window ? params.anchor.window->presentation().rounding() : ScrollOverview::Config::getValue<int>("decoration:rounding");
     const float SCALE    = std::max(params.renderScale, 0.01F) * std::max<float>(params.monitor ? params.monitor->m_scale : 1.F, 0.01F);
 
     return std::max(0, sc<int>(std::round(ROUNDING * SCALE)));
@@ -111,7 +112,7 @@ static int indicatorRounding(const CDropIndicator::SRenderParams& params) {
 
 static float indicatorRoundingPower(const CDropIndicator::SRenderParams& params) {
     if (params.anchor.window)
-        return params.anchor.window->roundingPower();
+        return params.anchor.window->presentation().roundingPower();
 
     return ScrollOverview::Config::getValue<float>("decoration:rounding_power");
 }

--- a/Window.cpp
+++ b/Window.cpp
@@ -12,6 +12,9 @@
 #include <hyprland/src/desktop/state/FocusState.hpp>
 #include <hyprland/src/desktop/state/WindowState.hpp>
 #include <hyprland/src/desktop/view/Group.hpp>
+#include <hyprland/src/desktop/view/window/Window.hpp>
+#include <hyprland/src/desktop/view/window/WindowGroupMembership.hpp>
+#include <hyprland/src/desktop/view/window/WindowPresentation.hpp>
 #include <hyprland/src/desktop/view/Popup.hpp>
 #include <hyprland/src/desktop/view/WLSurface.hpp>
 #include <hyprland/src/plugins/PluginSystem.hpp>
@@ -23,10 +26,12 @@
 #include <hyprland/src/render/pass/TexPassElement.hpp>
 #include <hyprland/src/render/types.hpp>
 #include <hyprland/src/render/decorations/CHyprGroupBarDecoration.hpp>
+#include <hyprland/src/render/decorations/CHyprBorderDecoration.hpp>
+#include <hyprland/src/render/decorations/CHyprDropShadowDecoration.hpp>
 #include <hyprland/src/render/decorations/DecorationPositioner.hpp>
 #include <hyprland/src/config/shared/complex/ComplexDataTypes.hpp>
 #include <hyprland/src/managers/fullscreen/FullscreenController.hpp>
-#include <hyprland/src/protocols/XDGShell.hpp>
+#include <hyprland/src/render/decorations/CHyprBorderDecoration.hpp>
 #include <hyprutils/utils/ScopeGuard.hpp>
 #undef protected
 #undef private
@@ -94,8 +99,8 @@ static PHLWINDOW getOverviewWindowToShow(const PHLWINDOW& window) {
     if (!window)
         return nullptr;
 
-    if (window->m_group)
-        return window->m_group->current();
+    if (window->grouping().group())
+        return window->grouping().group()->current();
 
     return window;
 }
@@ -106,7 +111,7 @@ static bool shouldShowOverviewWindow(const PHLWINDOW& window) {
     if (!validMapped(WINDOW))
         return false;
 
-    if (WINDOW->m_pinned && WINDOW->m_isFloating)
+    if ((WINDOW->m_state & Desktop::View::WINDOW_STATE_PINNED) && WINDOW->isFloating())
         return false;
 
     return true;
@@ -132,96 +137,57 @@ struct SOverviewPseudoFocusState {
     SP<Desktop::CFocusState>       focusState;
     PHLWINDOWREF                  previousFocusWindow;
     WP<CWLSurfaceResource>         previousFocusSurface;
-    Config::CGradientValueData     previousBorderColor;
-    Config::CGradientValueData     previousBorderColorPrevious;
-    Config::CGradientValueData     previousShadowColor;
-    Config::CGradientValueData     previousShadowColorPrevious;
-    Config::CGradientValueData     previousGlowColor;
-    Config::CGradientValueData     previousGlowColorPrevious;
     float                          previousOpacity = 1.F;
     float                          previousDim     = 0.F;
     bool                           active          = false;
+
+    static void refreshDecorationState(const PHLWINDOW& window) {
+        if (!window)
+            return;
+
+        for (const auto& deco : window->presentation().decorations()) {
+            if (deco)
+                deco->updateState();
+        }
+    }
 
     SOverviewPseudoFocusState(const PHLWINDOW& window_, const PHLWINDOW& pseudoFocusWindow) : window(window_) {
         if (!window || !pseudoFocusWindow)
             return;
 
-        active                      = true;
-        focusState                  = Desktop::focusState();
-        previousFocusWindow         = focusState->m_focusWindow;
-        previousFocusSurface        = focusState->m_focusSurface;
-        previousBorderColor         = window->m_realBorderColor;
-        previousBorderColorPrevious = window->m_realBorderColorPrevious;
-        previousShadowColor         = window->m_realShadowColor;
-        previousShadowColorPrevious = window->m_realShadowColorPrevious;
-        previousGlowColor           = window->m_realGlowColor;
-        previousGlowColorPrevious   = window->m_realGlowColorPrevious;
-        previousOpacity             = window->alpha(Desktop::View::WINDOW_ALPHA_ACTIVE)->value();
-        previousDim                 = window->m_dimPercent->value();
+        active               = true;
+        focusState           = Desktop::focusState();
+        previousFocusWindow  = focusState->m_focusWindow;
+        previousFocusSurface = focusState->m_focusSurface;
+        previousOpacity      = window->presentation().alpha(Desktop::View::WINDOW_ALPHA_ACTIVE)->value();
+        previousDim          = window->presentation().dimPercent();
 
         focusState->m_focusWindow = pseudoFocusWindow;
         if (pseudoFocusWindow->wlSurface() && pseudoFocusWindow->wlSurface()->resource())
             focusState->m_focusSurface = pseudoFocusWindow->wlSurface()->resource();
 
-        const bool ISACTIVE    = window == pseudoFocusWindow;
-        const bool GROUPLOCKED = (window->m_group && window->m_group->locked()) || Desktop::windowState()->groupsLocked();
-        const bool NOGROUP     = window->m_groupRules & Desktop::View::GROUP_DENY;
-        const auto BORDERKEY   = window->m_group ?
-            (ISACTIVE ? (GROUPLOCKED ? "group:col.border_locked_active" : "group:col.border_active") :
-                        (GROUPLOCKED ? "group:col.border_locked_inactive" : "group:col.border_inactive")) :
-            (ISACTIVE ? (NOGROUP ? "general:col.nogroup_border_active" : "general:col.active_border") :
-                        (NOGROUP ? "general:col.nogroup_border" : "general:col.inactive_border"));
-        const auto BORDERCOLOR = ScrollOverview::Config::getValue<Config::CGradientValueData>(BORDERKEY);
+        const bool ISACTIVE = window == pseudoFocusWindow;
+        window->presentation().alpha(Desktop::View::WINDOW_ALPHA_ACTIVE)->value() = getOverviewWindowTargetOpacity(window);
 
-        window->m_realBorderColor =
-            ISACTIVE ? window->m_ruleApplicator->activeBorderColor().valueOr(BORDERCOLOR) : window->m_ruleApplicator->inactiveBorderColor().valueOr(BORDERCOLOR);
-        window->m_realBorderColorPrevious = window->m_realBorderColor;
-
-        const auto SHADOWACTIVE   = ScrollOverview::Config::getValue<Config::CGradientValueData>("decoration:shadow:color");
-        const auto SHADOWINACTIVE = Config::mgr()->getConfigValue("decoration:shadow:color_inactive").setByUser ?
-            ScrollOverview::Config::getValue<Config::CGradientValueData>("decoration:shadow:color_inactive") :
-            SHADOWACTIVE;
-        const auto GLOWACTIVE     = ScrollOverview::Config::getValue<Config::CGradientValueData>("decoration:glow:color");
-        const auto GLOWINACTIVE   = Config::mgr()->getConfigValue("decoration:glow:color_inactive").setByUser ?
-            ScrollOverview::Config::getValue<Config::CGradientValueData>("decoration:glow:color_inactive") :
-            GLOWACTIVE;
-
-        if (window->isX11OverrideRedirect() || window->m_X11DoesntWantBorders) {
-            const Config::CGradientValueData TRANSPARENT{CHyprColor{0, 0, 0, 0}};
-            window->m_realShadowColor = TRANSPARENT;
-            window->m_realGlowColor   = TRANSPARENT;
-        } else {
-            window->m_realShadowColor = ISACTIVE ? SHADOWACTIVE : SHADOWINACTIVE;
-            window->m_realGlowColor   = ISACTIVE ? GLOWACTIVE : GLOWINACTIVE;
-        }
-        window->m_realShadowColorPrevious = window->m_realShadowColor;
-        window->m_realGlowColorPrevious   = window->m_realGlowColor;
-
-        window->alpha(Desktop::View::WINDOW_ALPHA_ACTIVE)->value() = getOverviewWindowTargetOpacity(window);
-
-        const bool ISMODALSHADOWED = window->m_xdgSurface && window->m_xdgSurface->m_toplevel && window->m_xdgSurface->m_toplevel->anyChildModal();
+        const bool ISMODALSHADOWED = window->backend().traits().hasModalChild;
         float      dim             = ISACTIVE || window->m_ruleApplicator->noDim().valueOrDefault() || !ScrollOverview::Config::getValue<bool>("decoration:dim_inactive") ?
                  0.F :
                  ScrollOverview::Config::getValue<float>("decoration:dim_strength");
         if (ISMODALSHADOWED && ScrollOverview::Config::getValue<bool>("decoration:dim_modal"))
             dim += (1.F - dim) / 2.F;
-        window->m_dimPercent->value() = dim;
+        window->presentation().m_dimPercent->value() = dim;
+        refreshDecorationState(window);
     }
 
     ~SOverviewPseudoFocusState() {
         if (!active)
             return;
 
-        window->m_realBorderColor         = previousBorderColor;
-        window->m_realBorderColorPrevious = previousBorderColorPrevious;
-        window->m_realShadowColor         = previousShadowColor;
-        window->m_realShadowColorPrevious = previousShadowColorPrevious;
-        window->m_realGlowColor           = previousGlowColor;
-        window->m_realGlowColorPrevious   = previousGlowColorPrevious;
-        window->alpha(Desktop::View::WINDOW_ALPHA_ACTIVE)->value() = previousOpacity;
-        window->m_dimPercent->value()                 = previousDim;
-        focusState->m_focusWindow                     = previousFocusWindow;
-        focusState->m_focusSurface                    = previousFocusSurface;
+        window->presentation().alpha(Desktop::View::WINDOW_ALPHA_ACTIVE)->value() = previousOpacity;
+        window->presentation().m_dimPercent->value()                             = previousDim;
+        focusState->m_focusWindow                                                = previousFocusWindow;
+        focusState->m_focusSurface                                               = previousFocusSurface;
+        refreshDecorationState(window);
     }
 };
 
@@ -233,8 +199,8 @@ static void roundStandaloneWindowPassElements(const PHLWINDOW& window, PHLMONITO
     if (Fullscreen::controller()->isFullscreen(window))
         return;
 
-    const int   rounding      = sc<int>(std::round(window->rounding() * monitor->m_scale * renderScale));
-    const float roundingPower = window->roundingPower();
+    const int   rounding      = sc<int>(std::round(window->presentation().rounding() * monitor->m_scale * renderScale));
+    const float roundingPower = window->presentation().roundingPower();
 
     if (rounding <= 0)
         return;
@@ -291,7 +257,7 @@ static float getOverviewHyprbarLogicalHeight(const PHLWINDOW& window) {
     if (!window || !window->m_ruleApplicator->decorate().valueOrDefault())
         return 0.F;
 
-    for (const auto& deco : window->m_windowDecorations) {
+    for (const auto& deco : window->presentation().decorations()) {
         if (!isOverviewHyprbarDecoration(deco.get()))
             continue;
 
@@ -347,7 +313,7 @@ static void scaleOverviewChildSurfaceGeometry(const PHLWINDOW& window, const Vec
     if (!window)
         return;
 
-    const auto REPORTEDSIZE = window->getReportedSize();
+    const auto REPORTEDSIZE = window->backend().reportedSize();
     if (REPORTEDSIZE.x <= 0 || REPORTEDSIZE.y <= 0)
         return;
 
@@ -420,11 +386,11 @@ static SOverviewWindowMetrics getOverviewWindowMetrics(PHLMONITOR monitor, const
         return metrics;
 
     metrics.pxScale                 = monitor->m_scale * renderScale;
-    metrics.borderSize              = window->getRealBorderSize();
+    metrics.borderSize              = window->presentation().borderSize();
     metrics.borderPx                = sc<int>(std::round(metrics.borderSize * monitor->m_scale));
     metrics.borderPxScaled          = metrics.borderSize * metrics.pxScale;
-    metrics.roundingBase            = window->rounding();
-    metrics.roundingPower           = window->roundingPower();
+    metrics.roundingBase            = window->presentation().rounding();
+    metrics.roundingPower           = window->presentation().roundingPower();
     metrics.correctionOffset        = metrics.borderSize * (M_SQRT2 - 1) * std::max(2.0 - metrics.roundingPower, 0.0);
     metrics.outerRound              = metrics.roundingBase > 0 ? (metrics.roundingBase + metrics.borderSize) - metrics.correctionOffset : 0.F;
     metrics.roundingPx              = sc<int>(std::round(metrics.roundingBase * metrics.pxScale));
@@ -448,7 +414,7 @@ static std::optional<SDecorationPositioningReply> getOverviewTopStickyDecoration
         return std::nullopt;
 
     const float HEIGHT  = std::max(0.F, sc<float>(INFO.desiredExtents.topLeft.y) * heightScale);
-    const float BORDER  = sc<float>(window->getRealBorderSize());
+    const float BORDER  = sc<float>(window->presentation().borderSize());
     const bool  PRECEDE = shouldOverviewBorderIncludeHyprbar(window);
     const float WIDTH   = PRECEDE ? window->size(Desktop::View::IGeometric::GEOMETRIC_CURRENT).x : window->size(Desktop::View::IGeometric::GEOMETRIC_CURRENT).x + BORDER * 2.F;
     const float YOFFSET = PRECEDE ? 0.F : BORDER;
@@ -501,22 +467,24 @@ static void renderOverviewHyprbarDecoration(SOverviewCustomDecorationRenderState
     const Vector2D previousWindowPos       = window->position(Desktop::View::IGeometric::GEOMETRIC_CURRENT);
     const Vector2D previousWindowSize      = window->size(Desktop::View::IGeometric::GEOMETRIC_CURRENT);
     const auto     WORKSPACE               = window->m_workspace;
-    const bool     OVERRIDEWORKSPACEOFFSET = WORKSPACE && !window->m_pinned;
+    const bool     OVERRIDEWORKSPACEOFFSET = WORKSPACE && !(window->m_state & Desktop::View::WINDOW_STATE_PINNED);
     const Vector2D previousWorkspaceOffset = OVERRIDEWORKSPACEOFFSET ? WORKSPACE->m_renderOffset->value() : Vector2D{};
     const auto     previousReplyData       = g_pDecorationPositioner->getDataFor(decoration, window);
     const auto     previousReply           = previousReplyData ? previousReplyData->lastReply : SDecorationPositioningReply{};
     const auto     previousRounding        = window->m_ruleApplicator->rounding();
     const auto     previousBorderSize      = window->m_ruleApplicator->borderSize();
-    const bool     previousBorderCacheDirty = window->m_borderSizeCacheDirty;
-    const int      previousCachedBorderSize = window->m_cachedBorderSize;
+    auto* const    BORDERDECO               = dc<CHyprBorderDecoration*>(window->presentation().decoration(DECORATION_BORDER).get());
+    const bool     previousBorderCacheDirty = BORDERDECO && BORDERDECO->m_borderSizeCacheDirty;
+    const int      previousCachedBorderSize = BORDERDECO ? BORDERDECO->m_cachedBorderSize : -1;
 
     const auto scaledRounding   = std::max<Config::INTEGER>(0, sc<Config::INTEGER>(std::round(window->m_ruleApplicator->rounding().valueOrDefault() * metrics.renderScale)));
-    const auto scaledBorderSize = std::max<Config::INTEGER>(0, sc<Config::INTEGER>(std::round(window->getRealBorderSize() * metrics.renderScale)));
+    const auto scaledBorderSize = std::max<Config::INTEGER>(0, sc<Config::INTEGER>(std::round(window->presentation().borderSize() * metrics.renderScale)));
     window->m_ruleApplicator->rounding().set(scaledRounding, Desktop::Types::PRIORITY_SET_PROP);
     window->m_ruleApplicator->borderSize().set(scaledBorderSize, Desktop::Types::PRIORITY_SET_PROP);
-    window->m_borderSizeCacheDirty = true;
+    if (BORDERDECO)
+        BORDERDECO->m_borderSizeCacheDirty = true;
 
-    window->positionAnimation()->value() = monitor->m_position + windowBox.pos() / monitor->m_scale - window->m_floatingOffset;
+    window->positionAnimation()->value() = monitor->m_position + windowBox.pos() / monitor->m_scale - window->presentation().floatingOffset();
     window->sizeAnimation()->value()     = windowBox.size() / monitor->m_scale;
 
     const auto REPLY = getOverviewTopStickyDecorationReply(decoration, window, metrics.renderScale);
@@ -527,8 +495,10 @@ static void renderOverviewHyprbarDecoration(SOverviewCustomDecorationRenderState
         ScrollOverview::Config::setValue("plugin:hyprbars:bar_button_padding", previousButtonPadding);
         window->m_ruleApplicator->roundingOverride(previousRounding);
         window->m_ruleApplicator->borderSizeOverride(previousBorderSize);
-        window->m_borderSizeCacheDirty = previousBorderCacheDirty;
-        window->m_cachedBorderSize     = previousCachedBorderSize;
+        if (auto* const BORDER = dc<CHyprBorderDecoration*>(window->presentation().decoration(DECORATION_BORDER).get())) {
+            BORDER->m_borderSizeCacheDirty = previousBorderCacheDirty;
+            BORDER->m_cachedBorderSize     = previousCachedBorderSize;
+        }
         if (HYPRBARGLOBALSTATE) {
             for (size_t i = 0; i < previousButtonSizes.size() && i < HYPRBARGLOBALSTATE->buttons.size(); ++i)
                 HYPRBARGLOBALSTATE->buttons[i].size = previousButtonSizes[i];
@@ -565,8 +535,10 @@ static void renderOverviewHyprbarDecoration(SOverviewCustomDecorationRenderState
         ScrollOverview::Config::setValue("plugin:hyprbars:bar_button_padding", previousButtonPadding);
         window->m_ruleApplicator->roundingOverride(previousRounding);
         window->m_ruleApplicator->borderSizeOverride(previousBorderSize);
-        window->m_borderSizeCacheDirty = previousBorderCacheDirty;
-        window->m_cachedBorderSize     = previousCachedBorderSize;
+        if (auto* const BORDER = dc<CHyprBorderDecoration*>(window->presentation().decoration(DECORATION_BORDER).get())) {
+            BORDER->m_borderSizeCacheDirty = previousBorderCacheDirty;
+            BORDER->m_cachedBorderSize     = previousCachedBorderSize;
+        }
         if (auto* const HYPRBARGLOBALSTATE = getOverviewHyprbarGlobalState()) {
             for (size_t i = 0; i < previousButtonSizes.size() && i < HYPRBARGLOBALSTATE->buttons.size(); ++i)
                 HYPRBARGLOBALSTATE->buttons[i].size = previousButtonSizes[i];
@@ -575,7 +547,7 @@ static void renderOverviewHyprbarDecoration(SOverviewCustomDecorationRenderState
 }
 
 static void renderOverviewWindowShadow(PHLMONITOR monitor, const PHLWINDOW& window, const CBox& windowBox, const SOverviewWindowMetrics& metrics, bool selected) {
-    if (!monitor || !window || (!window->m_isMapped))
+    if (!monitor || !window || (!window->mapped()))
         return;
 
     const auto PSHADOWS      = ScrollOverview::Config::getValue<int>("decoration:shadow:enabled");
@@ -586,7 +558,7 @@ static void renderOverviewWindowShadow(PHLMONITOR monitor, const PHLWINDOW& wind
     if (PSHADOWS != 1 || PSHADOWSIZE <= 0)
         return;
 
-    if (window->isX11OverrideRedirect() || window->m_X11DoesntWantBorders || !window->m_ruleApplicator->decorate().valueOrDefault() ||
+    if (window->backend().traits().overrideRedirect || window->backend().traits().suggestsNoBorder || !window->m_ruleApplicator->decorate().valueOrDefault() ||
         window->m_ruleApplicator->noShadow().valueOrDefault())
         return;
 
@@ -605,7 +577,11 @@ static void renderOverviewWindowShadow(PHLMONITOR monitor, const PHLWINDOW& wind
     if (shadowBox.width < 1 || shadowBox.height < 1)
         return;
 
-    const auto& shadowColor = window->m_realShadowColor;
+    auto* const SHADOWDECO = dc<CHyprDropShadowDecoration*>(window->presentation().decoration(DECORATION_SHADOW).get());
+    if (!SHADOWDECO)
+        return;
+    const auto  shadowState = SHADOWDECO->m_gradient.renderState();
+    const auto& shadowColor = shadowState.current;
     if (std::ranges::none_of(shadowColor.m_colors, [](const CHyprColor& color) { return color.a > 0.F; }))
         return;
 
@@ -624,13 +600,18 @@ static void renderOverviewWindowShadow(PHLMONITOR monitor, const PHLWINDOW& wind
 }
 
 static void renderOverviewWindowBorder(PHLMONITOR monitor, const PHLWINDOW& window, const CBox& windowBox, const SOverviewWindowMetrics& metrics, bool selected) {
-    if (!monitor || !window || (!window->m_isMapped))
+    if (!monitor || !window || (!window->mapped()))
         return;
 
     if (metrics.borderSize <= 0.F)
         return;
 
-    auto grad = window->m_realBorderColor;
+    auto* const BORDERDECO = dc<CHyprBorderDecoration*>(window->presentation().decoration(DECORATION_BORDER).get());
+    if (!BORDERDECO)
+        return;
+
+    const auto GRADIENT = BORDERDECO->m_gradient.renderState();
+    auto       grad     = GRADIENT.current;
 
     const CBox borderBox = getOverviewBorderBox(windowBox, metrics);
 
@@ -642,18 +623,18 @@ static void renderOverviewWindowBorder(PHLMONITOR monitor, const PHLWINDOW& wind
     data.roundingPower = metrics.roundingPower;
     data.a             = metrics.targetOpacity;
     data.borderSize    = metrics.borderSize;
-    if (window->m_borderFadeAnimationProgress->isBeingAnimated()) {
+    if (GRADIENT.transitioning) {
         data.hasGrad2 = true;
-        data.grad1    = window->m_realBorderColorPrevious;
+        data.grad1    = GRADIENT.previous;
         data.grad2    = grad;
-        data.lerp     = window->m_borderFadeAnimationProgress->value();
+        data.lerp     = GRADIENT.progress;
     } else
         data.grad1 = grad;
     g_pHyprRenderer->m_renderPass.add(makeUnique<CBorderPassElement>(data));
 }
 
 static void renderOverviewGroupTabIndicators(PHLMONITOR monitor, const PHLWINDOW& window, const CBox& windowBox, const SOverviewWindowMetrics& metrics, float alpha) {
-    if (!monitor || !window || !window->m_group || window->m_group->size() < 1)
+    if (!monitor || !window || !window->grouping().group() || window->grouping().group()->size() < 1)
         return;
 
     const auto PINDICATORHEIGHT = ScrollOverview::Config::getValue<int>("group:groupbar:indicator_height");
@@ -670,8 +651,8 @@ static void renderOverviewGroupTabIndicators(PHLMONITOR monitor, const PHLWINDOW
     if (PINDICATORHEIGHT <= 0)
         return;
 
-    const bool  groupLocked  = window->m_group->locked() || Desktop::windowState()->groupsLocked();
-    const auto  groupWindows = window->m_group->windows();
+    const bool  groupLocked  = window->grouping().group()->locked() || Desktop::windowState()->groupsLocked();
+    const auto  groupWindows = window->grouping().group()->windows();
     const auto  focusedWindow = Desktop::focusState()->window();
     const float indicatorH   = sc<float>(PINDICATORHEIGHT) * metrics.pxScale;
     const float outerGap     = sc<float>(POUTERGAP) * metrics.pxScale;
@@ -726,7 +707,7 @@ static void renderOverviewGroupTabIndicators(PHLMONITOR monitor, const PHLWINDOW
 }
 
 static void renderOverviewGroupTabTitles(PHLMONITOR monitor, const PHLWINDOW& window, const CBox& windowBox, const SOverviewWindowMetrics& metrics, float alpha) {
-    if (!monitor || !window || !window->m_group || window->m_group->size() < 1 || alpha <= 0.F)
+    if (!monitor || !window || !window->grouping().group() || window->grouping().group()->size() < 1 || alpha <= 0.F)
         return;
 
     const auto PRENDERTITLES            = ScrollOverview::Config::getValue<bool>("group:groupbar:render_titles");
@@ -747,8 +728,8 @@ static void renderOverviewGroupTabTitles(PHLMONITOR monitor, const PHLWINDOW& wi
     if (!PRENDERTITLES || PHEIGHT <= 0)
         return;
 
-    const bool  groupLocked  = window->m_group->locked() || Desktop::windowState()->groupsLocked();
-    const auto  groupWindows = window->m_group->windows();
+    const bool  groupLocked  = window->grouping().group()->locked() || Desktop::windowState()->groupsLocked();
+    const auto  groupWindows = window->grouping().group()->windows();
     const auto  focusedWindow = Desktop::focusState()->window();
     const float outerGap     = sc<float>(POUTERGAP) * metrics.pxScale;
     const float innerGap     = sc<float>(PINNERGAP) * metrics.pxScale;
@@ -809,7 +790,7 @@ static void renderOverviewGroupTabTitles(PHLMONITOR monitor, const PHLWINDOW& wi
 
         const int maxWidth = std::max(1, sc<int>(std::round(box.width - textPadding * 2.F)));
         auto      titleTex =
-            g_pHyprRenderer->renderText(member->m_title, textColor, fontSizePx, false, FONTFAMILY, maxWidth, isCurrent ? FONTWEIGHTACTIVE->m_value : FONTWEIGHTINACTIVE->m_value);
+            g_pHyprRenderer->renderText(member->metadata().title(), textColor, fontSizePx, false, FONTFAMILY, maxWidth, isCurrent ? FONTWEIGHTACTIVE->m_value : FONTWEIGHTINACTIVE->m_value);
         if (!titleTex || !titleTex->ok())
             continue;
 
@@ -830,10 +811,10 @@ static void renderOverviewGroupTabTitles(PHLMONITOR monitor, const PHLWINDOW& wi
 
 static void renderOverviewGroupTabs(PHLMONITOR monitor, const PHLWINDOW& window, const CBox& windowBox, const CBox& workspaceBox,
                                     const SOverviewWindowMetrics& metrics) {
-    if (!monitor || !window || !window->m_group || window->m_group->size() < 1)
+    if (!monitor || !window || !window->grouping().group() || window->grouping().group()->size() < 1)
         return;
 
-    auto* const GROUPBAR = dc<CHyprGroupBarDecoration*>(window->getDecorationByType(DECORATION_GROUPBAR));
+    auto* const GROUPBAR = dc<CHyprGroupBarDecoration*>(window->presentation().decoration(DECORATION_GROUPBAR).get());
     if (!GROUPBAR)
         return;
 
@@ -846,14 +827,14 @@ static void renderOverviewGroupTabs(PHLMONITOR monitor, const PHLWINDOW& window,
     const auto  POUTERGAP        = ScrollOverview::Config::getValue<int>("group:groupbar:gaps_out");
     const auto  PKEEPUPPERGAP    = ScrollOverview::Config::getValue<int>("group:groupbar:keep_upper_gap");
 
-    const auto  ONEBARHEIGHT     = POUTERGAP + PINDICATORHEIGHT + PINDICATORGAP + (PGRADIENTS || PRENDERTITLES ? PHEIGHT : 0);
-    const auto  DESIREDHEIGHT    = PSTACKED ? (ONEBARHEIGHT * window->m_group->size()) + POUTERGAP * PKEEPUPPERGAP : POUTERGAP * (1 + PKEEPUPPERGAP) + ONEBARHEIGHT;
-    const auto  EDGEPOINT        = g_pDecorationPositioner->getEdgeDefinedPoint(DECORATION_EDGE_TOP, window);
-    CBox        assignedBox      = {window->m_realPosition->value() - Vector2D{0.0, sc<double>(DESIREDHEIGHT) + metrics.hyprbarTopOffsetLogical},
-                                    Vector2D{window->m_realSize->value().x, sc<double>(DESIREDHEIGHT)}};
+    const auto   ONEBARHEIGHT  = POUTERGAP + PINDICATORHEIGHT + PINDICATORGAP + (PGRADIENTS || PRENDERTITLES ? PHEIGHT : 0);
+    const double DESIREDHEIGHT = sc<double>(PSTACKED ? (ONEBARHEIGHT * window->grouping().group()->size()) + POUTERGAP * PKEEPUPPERGAP : POUTERGAP * (1 + PKEEPUPPERGAP) + ONEBARHEIGHT);
+    const auto   EDGEPOINT     = g_pDecorationPositioner->getEdgeDefinedPoint(DECORATION_EDGE_TOP, window);
+    CBox         assignedBox   = {window->positionAnimation()->value() - Vector2D(0.0, DESIREDHEIGHT + metrics.hyprbarTopOffsetLogical),
+                          Vector2D(window->sizeAnimation()->value().x, DESIREDHEIGHT)};
     assignedBox.translate(-EDGEPOINT);
 
-    if (window->m_workspace && !window->m_pinned)
+    if (window->m_workspace && !(window->m_state & Desktop::View::WINDOW_STATE_PINNED))
         assignedBox.translate(-window->m_workspace->m_renderOffset->value());
 
     const auto PREVASSIGNEDBOX = GROUPBAR->m_assignedBox;
@@ -878,14 +859,14 @@ static SOverviewCustomDecorationRenderState renderOverviewCustomDecorations(PHLM
     if (!monitor || !window)
         return state;
 
-    window->updateWindowDecos();
+    window->presentation().updateDecorations();
 
     Render::SRenderModifData modif;
     modif.modifs.emplace_back(Render::SRenderModifData::RMOD_TYPE_SCALE, metrics.renderScale);
     modif.modifs.emplace_back(Render::SRenderModifData::RMOD_TYPE_TRANSLATE, workspaceBox.pos());
     bool        drewAny = false;
 
-    for (const auto& deco : window->m_windowDecorations) {
+    for (const auto& deco : window->presentation().decorations()) {
         if (!deco || deco->getDecorationType() != DECORATION_CUSTOM || deco->getDecorationLayer() != layer)
             continue;
 
@@ -938,7 +919,7 @@ static bool overviewWorkspaceBoxReadyForPrecomputedBlur(PHLMONITOR monitor, cons
 }
 
 bool shouldUsePrecomputedBlur(const PHLWINDOW& window, PHLMONITOR monitor, const CBox* workspaceBox, const CBox* windowBox, bool dragged) {
-    return !dragged && ScrollOverview::Config::getValue<bool>("decoration:blur:new_optimizations") && shouldShowOverviewWindow(window) && !window->m_isFloating && shouldBlurBackground(window) &&
+    return !dragged && ScrollOverview::Config::getValue<bool>("decoration:blur:new_optimizations") && shouldShowOverviewWindow(window) && !window->isFloating() && shouldBlurBackground(window) &&
         overviewWindowFitsWorkspaceBox(workspaceBox, windowBox) && overviewWorkspaceBoxReadyForPrecomputedBlur(monitor, workspaceBox);
 }
 
@@ -954,7 +935,7 @@ void forceDecoRecalc(const PHLWINDOW& window) {
         return;
 
     g_pDecorationPositioner->forceRecalcFor(WINDOW);
-    WINDOW->updateWindowDecos();
+    WINDOW->presentation().updateDecorations();
 }
 
 void renderOverviewWindow(const SRenderParams& params) {
@@ -976,17 +957,17 @@ void renderOverviewWindow(const SRenderParams& params) {
             (*it)();
     }
 
-    const Vector2D previousWindowPos       = params.window->m_realPosition->value();
-    const Vector2D previousWindowSize      = params.window->m_realSize->value();
-    const bool     previousAnimatingIn     = params.window->m_animatingIn;
+    const Vector2D previousWindowPos       = params.window->positionAnimation()->value();
+    const Vector2D previousWindowSize      = params.window->sizeAnimation()->value();
+    const bool     previousAnimatingIn     = params.window->presentation().animatingIn();
     const bool     previousSizeAnimating   = params.window->sizeAnimation()->isBeingAnimated();
     const auto     WORKSPACE               = params.window->m_workspace;
-    const bool     OVERRIDEWORKSPACEOFFSET = WORKSPACE && !params.window->m_pinned;
+    const bool     OVERRIDEWORKSPACEOFFSET = WORKSPACE && !(params.window->m_state & Desktop::View::WINDOW_STATE_PINNED);
     const Vector2D previousWorkspaceOffset = OVERRIDEWORKSPACEOFFSET ? WORKSPACE->m_renderOffset->value() : Vector2D{};
 
-    params.window->positionAnimation()->value() = params.monitor->m_position + params.windowBox.pos() / params.monitor->m_scale - params.window->m_floatingOffset;
+    params.window->positionAnimation()->value() = params.monitor->m_position + params.windowBox.pos() / params.monitor->m_scale - params.window->presentation().floatingOffset();
     params.window->sizeAnimation()->value()     = params.windowBox.size() / params.monitor->m_scale;
-    params.window->m_animatingIn                 = true;
+    params.window->presentation().setAnimatingIn(true);
     COverviewAnimatedVariableAccess::setBeingAnimated(params.window->sizeAnimation().get(), true);
     if (OVERRIDEWORKSPACEOFFSET)
         WORKSPACE->m_renderOffset->value() = {};
@@ -994,7 +975,7 @@ void renderOverviewWindow(const SRenderParams& params) {
     auto restoreWindowGeometry = Hyprutils::Utils::CScopeGuard([&] {
         params.window->positionAnimation()->value() = previousWindowPos;
         params.window->sizeAnimation()->value()     = previousWindowSize;
-        params.window->m_animatingIn                 = previousAnimatingIn;
+        params.window->presentation().setAnimatingIn(previousAnimatingIn);
         COverviewAnimatedVariableAccess::setBeingAnimated(params.window->sizeAnimation().get(), previousSizeAnimating);
         if (OVERRIDEWORKSPACEOFFSET && WORKSPACE)
             WORKSPACE->m_renderOffset->value() = previousWorkspaceOffset;

--- a/Window.cpp
+++ b/Window.cpp
@@ -26,7 +26,7 @@
 #include <hyprland/src/render/pass/TexPassElement.hpp>
 #include <hyprland/src/render/types.hpp>
 #include <hyprland/src/render/decorations/CHyprGroupBarDecoration.hpp>
-#include <hyprland/src/render/decorations/CHyprBorderDecoration.hpp>
+#include <hyprland/src/render/decorations/CHyprInnerGlowDecoration.hpp>
 #include <hyprland/src/render/decorations/CHyprDropShadowDecoration.hpp>
 #include <hyprland/src/render/decorations/DecorationPositioner.hpp>
 #include <hyprland/src/config/shared/complex/ComplexDataTypes.hpp>
@@ -137,18 +137,22 @@ struct SOverviewPseudoFocusState {
     SP<Desktop::CFocusState>       focusState;
     PHLWINDOWREF                  previousFocusWindow;
     WP<CWLSurfaceResource>         previousFocusSurface;
+    CHyprBorderDecoration*         borderDecoration = nullptr;
+    CHyprDropShadowDecoration*     shadowDecoration = nullptr;
+    CHyprInnerGlowDecoration*      glowDecoration = nullptr;
+    Config::CGradientValueData     previousBorderColor;
+    Config::CGradientValueData     previousBorderColorPrevious;
+    Config::CGradientValueData     previousShadowColor;
+    Config::CGradientValueData     previousShadowColorPrevious;
+    Config::CGradientValueData     previousGlowColor;
+    Config::CGradientValueData     previousGlowColorPrevious;
     float                          previousOpacity = 1.F;
     float                          previousDim     = 0.F;
     bool                           active          = false;
 
-    static void refreshDecorationState(const PHLWINDOW& window) {
-        if (!window)
-            return;
-
-        for (const auto& deco : window->presentation().decorations()) {
-            if (deco)
-                deco->updateState();
-        }
+    static void setGradientState(CAnimatedDecorationGradient& gradient, const Config::CGradientValueData& value) {
+        gradient.m_current  = value;
+        gradient.m_previous = value;
     }
 
     SOverviewPseudoFocusState(const PHLWINDOW& window_, const PHLWINDOW& pseudoFocusWindow) : window(window_) {
@@ -162,11 +166,54 @@ struct SOverviewPseudoFocusState {
         previousOpacity      = window->presentation().alpha(Desktop::View::WINDOW_ALPHA_ACTIVE)->value();
         previousDim          = window->presentation().dimPercent();
 
+        borderDecoration = dc<CHyprBorderDecoration*>(window->presentation().decoration(DECORATION_BORDER).get());
+        shadowDecoration = dc<CHyprDropShadowDecoration*>(window->presentation().decoration(DECORATION_SHADOW).get());
+        glowDecoration   = dc<CHyprInnerGlowDecoration*>(window->presentation().decoration(DECORATION_INNER_GLOW).get());
+
+        if (borderDecoration) {
+            previousBorderColor         = borderDecoration->m_gradient.m_current;
+            previousBorderColorPrevious = borderDecoration->m_gradient.m_previous;
+        }
+        if (shadowDecoration) {
+            previousShadowColor         = shadowDecoration->m_gradient.m_current;
+            previousShadowColorPrevious = shadowDecoration->m_gradient.m_previous;
+        }
+        if (glowDecoration) {
+            previousGlowColor         = glowDecoration->m_gradient.m_current;
+            previousGlowColorPrevious = glowDecoration->m_gradient.m_previous;
+        }
+
         focusState->m_focusWindow = pseudoFocusWindow;
         if (pseudoFocusWindow->wlSurface() && pseudoFocusWindow->wlSurface()->resource())
             focusState->m_focusSurface = pseudoFocusWindow->wlSurface()->resource();
 
-        const bool ISACTIVE = window == pseudoFocusWindow;
+        const bool ISACTIVE    = window == pseudoFocusWindow;
+        const bool GROUPLOCKED = (window->grouping().group() && window->grouping().group()->locked()) || Desktop::windowState()->groupsLocked();
+        const bool NOGROUP     = window->grouping().rules() & Desktop::View::GROUP_DENY;
+        const auto BORDERKEY   = window->grouping().group() ?
+            (ISACTIVE ? (GROUPLOCKED ? "group:col.border_locked_active" : "group:col.border_active") :
+                        (GROUPLOCKED ? "group:col.border_locked_inactive" : "group:col.border_inactive")) :
+            (ISACTIVE ? (NOGROUP ? "general:col.nogroup_border_active" : "general:col.active_border") :
+                        (NOGROUP ? "general:col.nogroup_border" : "general:col.inactive_border"));
+        const auto BORDERCOLOR = ScrollOverview::Config::getValue<Config::CGradientValueData>(BORDERKEY);
+        const auto BORDER       = ISACTIVE ? window->m_ruleApplicator->activeBorderColor().valueOr(BORDERCOLOR) :
+            window->m_ruleApplicator->inactiveBorderColor().valueOr(BORDERCOLOR);
+
+        const auto SHADOWACTIVE   = ScrollOverview::Config::getValue<Config::CGradientValueData>("decoration:shadow:color");
+        const auto SHADOWINACTIVE = Config::mgr()->getConfigValue("decoration:shadow:color_inactive").setByUser ?
+            ScrollOverview::Config::getValue<Config::CGradientValueData>("decoration:shadow:color_inactive") : SHADOWACTIVE;
+        const auto GLOWACTIVE     = ScrollOverview::Config::getValue<Config::CGradientValueData>("decoration:glow:color");
+        const auto GLOWINACTIVE   = Config::mgr()->getConfigValue("decoration:glow:color_inactive").setByUser ?
+            ScrollOverview::Config::getValue<Config::CGradientValueData>("decoration:glow:color_inactive") : GLOWACTIVE;
+        const Config::CGradientValueData TRANSPARENT{CHyprColor{0, 0, 0, 0}};
+
+        if (borderDecoration)
+            setGradientState(borderDecoration->m_gradient, BORDER);
+        if (shadowDecoration)
+            setGradientState(shadowDecoration->m_gradient, window->backend().traits().overrideRedirect || window->backend().traits().suggestsNoBorder ? TRANSPARENT : (ISACTIVE ? SHADOWACTIVE : SHADOWINACTIVE));
+        if (glowDecoration)
+            setGradientState(glowDecoration->m_gradient, window->backend().traits().overrideRedirect || window->backend().traits().suggestsNoBorder ? TRANSPARENT : (ISACTIVE ? GLOWACTIVE : GLOWINACTIVE));
+
         window->presentation().alpha(Desktop::View::WINDOW_ALPHA_ACTIVE)->value() = getOverviewWindowTargetOpacity(window);
 
         const bool ISMODALSHADOWED = window->backend().traits().hasModalChild;
@@ -176,18 +223,28 @@ struct SOverviewPseudoFocusState {
         if (ISMODALSHADOWED && ScrollOverview::Config::getValue<bool>("decoration:dim_modal"))
             dim += (1.F - dim) / 2.F;
         window->presentation().m_dimPercent->value() = dim;
-        refreshDecorationState(window);
     }
 
     ~SOverviewPseudoFocusState() {
         if (!active)
             return;
 
+        if (borderDecoration) {
+            borderDecoration->m_gradient.m_current  = previousBorderColor;
+            borderDecoration->m_gradient.m_previous = previousBorderColorPrevious;
+        }
+        if (shadowDecoration) {
+            shadowDecoration->m_gradient.m_current  = previousShadowColor;
+            shadowDecoration->m_gradient.m_previous = previousShadowColorPrevious;
+        }
+        if (glowDecoration) {
+            glowDecoration->m_gradient.m_current  = previousGlowColor;
+            glowDecoration->m_gradient.m_previous = previousGlowColorPrevious;
+        }
         window->presentation().alpha(Desktop::View::WINDOW_ALPHA_ACTIVE)->value() = previousOpacity;
-        window->presentation().m_dimPercent->value()                             = previousDim;
-        focusState->m_focusWindow                                                = previousFocusWindow;
-        focusState->m_focusSurface                                               = previousFocusSurface;
-        refreshDecorationState(window);
+        window->presentation().m_dimPercent->value() = previousDim;
+        focusState->m_focusWindow  = previousFocusWindow;
+        focusState->m_focusSurface = previousFocusSurface;
     }
 };
 

--- a/main.cpp
+++ b/main.cpp
@@ -5,7 +5,7 @@
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/desktop/state/FocusState.hpp>
 #include <hyprland/src/desktop/Workspace.hpp>
-#include <hyprland/src/desktop/view/Window.hpp>
+#include <hyprland/src/desktop/view/window/Window.hpp>
 #include <hyprland/src/config/ConfigManager.hpp>
 #include <hyprland/src/config/shared/actions/ConfigActions.hpp>
 #include <hyprland/src/desktop/DesktopTypes.hpp>

--- a/scrollOverview.cpp
+++ b/scrollOverview.cpp
@@ -36,7 +36,9 @@
 #include <hyprland/src/pointer/cursor/CursorShapeOverrideController.hpp>
 #include <hyprland/src/desktop/state/FocusState.hpp>
 #include <hyprland/src/desktop/view/Group.hpp>
-#include <hyprland/src/desktop/view/Window.hpp>
+#include <hyprland/src/desktop/view/window/Window.hpp>
+#include <hyprland/src/desktop/view/window/WindowGroupMembership.hpp>
+#include <hyprland/src/desktop/view/window/WindowPresentation.hpp>
 #include <hyprland/src/desktop/view/WLSurface.hpp>
 #include <hyprland/src/desktop/view/LayerSurface.hpp>
 #include <hyprland/src/desktop/view/Popup.hpp>
@@ -243,8 +245,8 @@ static PHLWINDOW getOverviewWindowToShow(const PHLWINDOW& window) {
     if (!window)
         return nullptr;
 
-    if (window->m_group)
-        return window->m_group->current();
+    if (window->grouping().group())
+        return window->grouping().group()->current();
 
     return window;
 }
@@ -255,7 +257,7 @@ static bool shouldShowOverviewWindow(const PHLWINDOW& window) {
     if (!validMapped(WINDOW))
         return false;
 
-    if (WINDOW->m_pinned && WINDOW->m_isFloating)
+    if ((WINDOW->m_state & Desktop::View::WINDOW_STATE_PINNED) && WINDOW->isFloating())
         return false;
 
     return true;
@@ -267,7 +269,7 @@ static bool shouldShowPinnedFloatingOverviewWindow(const PHLWINDOW& window) {
     if (!validMapped(WINDOW))
         return false;
 
-    if (!WINDOW->m_pinned || !WINDOW->m_isFloating)
+    if (!(WINDOW->m_state & Desktop::View::WINDOW_STATE_PINNED) || !WINDOW->isFloating())
         return false;
 
     return true;
@@ -308,9 +310,7 @@ static bool windowHasOverviewAnimation(const PHLWINDOW& window) {
     if (!window)
         return false;
 
-    return window->positionAnimation()->isBeingAnimated() || window->sizeAnimation()->isBeingAnimated() || window->m_alpha.isBeingAnimated() ||
-        window->m_borderFadeAnimationProgress->isBeingAnimated() || window->m_borderAngleAnimationProgress->isBeingAnimated() || window->m_dimPercent->isBeingAnimated() ||
-        window->m_shadowFadeAnimationProgress->isBeingAnimated();
+    return window->positionAnimation()->isBeingAnimated() || window->sizeAnimation()->isBeingAnimated() || window->alpha().isBeingAnimated();
 }
 
 static bool layerHasOverviewAnimation(const PHLLS& layer) {
@@ -354,7 +354,7 @@ static CBox getOverviewDragWindowBox(const PHLWINDOW& window, PHLMONITOR monitor
         return {};
 
     const auto TARGET = window->layoutTarget();
-    if (window->m_group && TARGET)
+    if (window->grouping().group() && TARGET)
         return getOverviewGlobalBox(TARGET->position(), monitor, scale, viewOffset, offset, layout, round);
 
     return getOverviewWindowBox(window, monitor, scale, viewOffset, offset, layout, round);
@@ -1495,7 +1495,7 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_, PHLMONITO
         const auto overviewWindow = getOverviewWindowToShow(window);
         const auto fullscreenWindow = overviewWindow && overviewWindow->m_workspace ? getOverviewWindowToShow(Fullscreen::controller()->getFullscreenWindow(overviewWindow->m_workspace)) : PHLWINDOW{};
 
-        if (shouldShowOverviewWindow(fullscreenWindow) && fullscreenWindow->m_workspace == overviewWindow->m_workspace && overviewWindow->m_isFloating)
+        if (shouldShowOverviewWindow(fullscreenWindow) && fullscreenWindow->m_workspace == overviewWindow->m_workspace && overviewWindow->isFloating())
             emitFullscreenVisibilityState(fullscreenWindow, true);
         else
             emitFullscreenVisibilityState(overviewWindow, true);
@@ -1935,7 +1935,7 @@ void CScrollOverview::updateWorkspaceOverflow() {
 
         for (const auto& windowRef : img->windows) {
             const auto window = getOverviewWindowToShow(windowRef.lock());
-            if (!shouldShowOverviewWindow(window) || window->m_isFloating)
+            if (!shouldShowOverviewWindow(window) || window->isFloating())
                 continue;
 
             const auto POS  = window->position(Desktop::View::IGeometric::GEOMETRIC_CURRENT) - MONITOR->m_position;
@@ -1993,7 +1993,7 @@ PHLWINDOW CScrollOverview::windowAtOverviewPoint(const Vector2D& point, size_t* 
         if (!isWorkspaceScrolling(wimg->pWorkspace) && shouldShowOverviewWindow(fullscreenWindow)) {
             for (auto it = wimg->windows.rbegin(); it != wimg->windows.rend(); ++it) {
                 const auto window = getOverviewWindowToShow(it->lock());
-                if (!shouldShowOverviewWindow(window) || !window->m_isFloating)
+                if (!shouldShowOverviewWindow(window) || !window->isFloating())
                     continue;
 
                 const auto texbox = getOverviewWindowBox(window, MONITOR, scale->value(), viewOffset->value(), offset, layout);
@@ -2013,7 +2013,7 @@ PHLWINDOW CScrollOverview::windowAtOverviewPoint(const Vector2D& point, size_t* 
         for (const bool floating : {true, false}) {
             for (auto it = wimg->windows.rbegin(); it != wimg->windows.rend(); ++it) {
                 const auto window = getOverviewWindowToShow(it->lock());
-                if (!shouldShowOverviewWindow(window) || window->m_isFloating != floating)
+                if (!shouldShowOverviewWindow(window) || window->isFloating() != floating)
                     continue;
 
                 const auto texbox = getOverviewWindowBox(window, MONITOR, scale->value(), viewOffset->value(), offset, layout);
@@ -2052,7 +2052,7 @@ PHLWINDOW CScrollOverview::windowClosestToWorkspaceCenter(size_t workspaceIdx) c
         const auto WINDOW = getOverviewWindowToShow(windowRef.lock());
         if (!shouldShowOverviewWindow(WINDOW))
             continue;
-        if (HASFULLSCREENPATH && WINDOW != FULLSCREENWINDOW && !WINDOW->m_isFloating)
+        if (HASFULLSCREENPATH && WINDOW != FULLSCREENWINDOW && !WINDOW->isFloating())
             continue;
 
         const auto WINDOWBOX = getOverviewWindowBox(WINDOW, MONITOR, SCALE, viewOffset->value(), WORKSPACEOFFSET, layout);
@@ -2082,7 +2082,7 @@ PHLWINDOW CScrollOverview::windowAtOverviewCursorOnWorkspace(size_t workspaceIdx
     for (const bool floating : {true, false}) {
         for (auto it = images[workspaceIdx]->windows.rbegin(); it != images[workspaceIdx]->windows.rend(); ++it) {
             const auto WINDOW = getOverviewWindowToShow(it->lock());
-            if (!shouldShowOverviewWindow(WINDOW) || WINDOW == ignoredWindow || WINDOW->m_isFloating != floating)
+            if (!shouldShowOverviewWindow(WINDOW) || WINDOW == ignoredWindow || WINDOW->isFloating() != floating)
                 continue;
 
             const auto box    = getOverviewWindowBox(WINDOW, MONITOR, scale->value(), viewOffset->value(), WORKSPACE_OFFSET, layout);
@@ -2237,7 +2237,7 @@ CDropIndicator::SDropAnchor CScrollOverview::dropAnchorAtOverviewCursorOnWorkspa
     float bestDistanceSq = std::numeric_limits<float>::max();
     for (auto it = IMAGE->windows.rbegin(); it != IMAGE->windows.rend(); ++it) {
         const auto WINDOW = getOverviewWindowToShow(it->lock());
-        if (!shouldShowOverviewWindow(WINDOW) || WINDOW == ignoredWindow || WINDOW->m_isFloating)
+        if (!shouldShowOverviewWindow(WINDOW) || WINDOW == ignoredWindow || WINDOW->isFloating())
             continue;
 
         const auto [BOX, LOGICALBOX] = boxesForWindow(WINDOW);
@@ -2268,7 +2268,7 @@ CDropIndicator::SDropAnchor CScrollOverview::dropAnchorAtOverviewCursorOnWorkspa
 
     for (const auto& windowRef : IMAGE->windows) {
         const auto WINDOW = getOverviewWindowToShow(windowRef.lock());
-        if (!shouldShowOverviewWindow(WINDOW) || WINDOW == ignoredWindow || WINDOW->m_isFloating)
+        if (!shouldShowOverviewWindow(WINDOW) || WINDOW == ignoredWindow || WINDOW->isFloating())
             continue;
 
         const auto [BOX, LOGICALBOX] = boxesForWindow(WINDOW);
@@ -2288,7 +2288,7 @@ CDropIndicator::SDropAnchor CScrollOverview::dropAnchorAtOverviewCursorOnWorkspa
 
     for (const auto& windowRef : IMAGE->windows) {
         const auto WINDOW = getOverviewWindowToShow(windowRef.lock());
-        if (!shouldShowOverviewWindow(WINDOW) || WINDOW == ignoredWindow || WINDOW->m_isFloating)
+        if (!shouldShowOverviewWindow(WINDOW) || WINDOW == ignoredWindow || WINDOW->isFloating())
             continue;
 
         const auto [BOX, LOGICALBOX] = boxesForWindow(WINDOW);
@@ -2352,7 +2352,7 @@ PHLWORKSPACE CScrollOverview::workspaceAtOverviewDropPoint(const Vector2D& point
         for (const bool floating : {true, false}) {
             for (auto it = wimg->windows.rbegin(); it != wimg->windows.rend(); ++it) {
                 const auto WINDOW = getOverviewWindowToShow(it->lock());
-                if (!shouldShowOverviewWindow(WINDOW) || WINDOW == draggedWindow || WINDOW->m_isFloating != floating)
+                if (!shouldShowOverviewWindow(WINDOW) || WINDOW == draggedWindow || WINDOW->isFloating() != floating)
                     continue;
 
                 const auto WINDOWBOX = getOverviewDragWindowBox(WINDOW, MONITOR, scale->value(), viewOffset->value(), WORKSPACEOFFSET, layout);
@@ -2579,7 +2579,7 @@ void CScrollOverview::refreshDragOriginalOverviewBoxes() {
 CBox CScrollOverview::resizedWindowBox() const {
     const auto WINDOW  = getOverviewWindowToShow(resizeActiveWindow.lock());
     const auto MONITOR = pMonitor.lock();
-    if (!WINDOW || !MONITOR || resizeWorkspaceIdx >= images.size() || !WINDOW->m_isFloating)
+    if (!WINDOW || !MONITOR || resizeWorkspaceIdx >= images.size() || !WINDOW->isFloating())
         return {};
 
     const float SCALEFACTOR = std::max(scale->value(), 0.01F) * std::max(MONITOR->m_scale, 0.01F);
@@ -2602,7 +2602,7 @@ CBox CScrollOverview::resizedWindowBox() const {
 
     const auto WORKSPACEOFFSET = workspaceOverviewOffset(resizeWorkspaceIdx, activeWorkspaceIndex(), getWorkspaceRenderedPitch(MONITOR, scale->value(), layout));
     const auto WORKSPACEBOX = getOverviewWorkspaceBox(MONITOR, scale->value(), viewOffset->value(), WORKSPACEOFFSET, layout);
-    const auto BORDERMARGIN = WINDOW->getRealBorderSize() * MONITOR->m_scale * scale->value();
+    const auto BORDERMARGIN = WINDOW->presentation().borderSize() * MONITOR->m_scale * scale->value();
 
     return clampResizedOverviewBoxToWorkspace(box, WORKSPACEBOX, resizeCorner, BORDERMARGIN);
 }
@@ -2633,7 +2633,7 @@ void CScrollOverview::beginWindowDrag(PHLWINDOW window) {
     dragOriginalTapeTranslation  = Vector2D{};
     dragOriginalWorkspace         = WINDOW->m_workspace;
     dragOriginalBox               = TARGET->position();
-    dragOriginalVisualBox         = WINDOW->m_group ? TARGET->position() : WINDOW->geometricBox(Desktop::View::IGeometric::GEOMETRIC_CURRENT);
+    dragOriginalVisualBox         = WINDOW->grouping().group() ? TARGET->position() : WINDOW->geometricBox(Desktop::View::IGeometric::GEOMETRIC_CURRENT);
     dragOriginalOverviewBox       = CBox{};
     dragOriginalOverviewHitbox    = CBox{};
     dragActiveWindow              = WINDOW;
@@ -2706,7 +2706,7 @@ void CScrollOverview::updateWindowResize() {
 
     TARGET->damageEntire();
 
-    if (WINDOW->m_isFloating) {
+    if (WINDOW->isFloating()) {
         const auto RESIZEDBOX  = resizedWindowBox();
         const auto SCALEFACTOR = std::max(scale->value(), 0.01F) * std::max(MONITOR->m_scale, 0.01F);
         const auto GLOBALBOX   = CBox{overviewPointToGlobal(resizeWorkspaceIdx, RESIZEDBOX.pos()), RESIZEDBOX.size() * (1.F / SCALEFACTOR)};
@@ -2828,7 +2828,7 @@ void CScrollOverview::focusMostVisibleScrollingWindow(const PHLWORKSPACE& worksp
         WORKSPACEBOX.translate(MONITOR->m_position);
 
     const auto preferredWindow = getOverviewWindowToShow(scrollingPanInitialWindow.lock());
-    if (shouldShowOverviewWindow(preferredWindow) && preferredWindow->m_workspace == workspace && !preferredWindow->m_isFloating && preferredWindow->layoutTarget()) {
+    if (shouldShowOverviewWindow(preferredWindow) && preferredWindow->m_workspace == workspace && !preferredWindow->isFloating() && preferredWindow->layoutTarget()) {
         const auto WINDOWBOX   = preferredWindow->layoutTarget()->position();
         const auto AREA        = overviewBoxArea(WINDOWBOX);
         const auto VISIBLEAREA = overviewBoxIntersectionArea(WINDOWBOX, WORKSPACEBOX);
@@ -2842,7 +2842,7 @@ void CScrollOverview::focusMostVisibleScrollingWindow(const PHLWORKSPACE& worksp
 
     for (const auto& windowRef : Desktop::windowState()->windows()) {
         const auto WINDOW = getOverviewWindowToShow(windowRef);
-        if (!shouldShowOverviewWindow(WINDOW) || WINDOW->m_workspace != workspace || WINDOW->m_isFloating || !WINDOW->layoutTarget())
+        if (!shouldShowOverviewWindow(WINDOW) || WINDOW->m_workspace != workspace || WINDOW->isFloating() || !WINDOW->layoutTarget())
             continue;
 
         const auto WINDOWBOX = WINDOW->layoutTarget()->position();
@@ -2891,7 +2891,7 @@ bool CScrollOverview::moveScrollingColumnSelection(bool next) {
     if (!ALGO || !ALGO->m_scrollingData || ALGO->m_scrollingData->columns.empty())
         return false;
 
-    if (!closeOnWindow || closeOnWindow->m_workspace != WORKSPACEIMAGE->pWorkspace || !shouldShowOverviewWindow(closeOnWindow.lock()) || closeOnWindow->m_isFloating)
+    if (!closeOnWindow || closeOnWindow->m_workspace != WORKSPACEIMAGE->pWorkspace || !shouldShowOverviewWindow(closeOnWindow.lock()) || closeOnWindow->isFloating())
         syncSelectionToViewport();
 
     const auto CURRENT = getOverviewWindowToShow(closeOnWindow.lock());
@@ -2910,7 +2910,7 @@ bool CScrollOverview::moveScrollingColumnSelection(bool next) {
 
             for (const auto& windowRef : WORKSPACEIMAGE->windows) {
                 const auto WINDOW = getOverviewWindowToShow(windowRef.lock());
-                if (shouldShowOverviewWindow(WINDOW) && !WINDOW->m_isFloating && WINDOW->layoutTarget() == targetData->target && WINDOW->m_workspace == WORKSPACEIMAGE->pWorkspace)
+                if (shouldShowOverviewWindow(WINDOW) && !WINDOW->isFloating() && WINDOW->layoutTarget() == targetData->target && WINDOW->m_workspace == WORKSPACEIMAGE->pWorkspace)
                     return WINDOW;
             }
         }
@@ -2973,7 +2973,7 @@ bool CScrollOverview::moveScrollingStackSelection(bool next) {
     if (!ALGO || !ALGO->m_scrollingData || ALGO->m_scrollingData->columns.empty())
         return false;
 
-    if (!closeOnWindow || closeOnWindow->m_workspace != WORKSPACEIMAGE->pWorkspace || !shouldShowOverviewWindow(closeOnWindow.lock()) || closeOnWindow->m_isFloating)
+    if (!closeOnWindow || closeOnWindow->m_workspace != WORKSPACEIMAGE->pWorkspace || !shouldShowOverviewWindow(closeOnWindow.lock()) || closeOnWindow->isFloating())
         syncSelectionToViewport();
 
     const auto CURRENT = getOverviewWindowToShow(closeOnWindow.lock());
@@ -2996,7 +2996,7 @@ bool CScrollOverview::moveScrollingStackSelection(bool next) {
 
     for (const auto& windowRef : WORKSPACEIMAGE->windows) {
         const auto WINDOW = getOverviewWindowToShow(windowRef.lock());
-        if (shouldShowOverviewWindow(WINDOW) && !WINDOW->m_isFloating && WINDOW->layoutTarget() == TARGETDATA->target && WINDOW->m_workspace == WORKSPACEIMAGE->pWorkspace) {
+        if (shouldShowOverviewWindow(WINDOW) && !WINDOW->isFloating() && WINDOW->layoutTarget() == TARGETDATA->target && WINDOW->m_workspace == WORKSPACEIMAGE->pWorkspace) {
             closeOnWindow = WINDOW;
             rememberSelection(WINDOW);
             syncFocusedSelection();
@@ -3043,7 +3043,7 @@ void CScrollOverview::endWindowDrag() {
     }
 
     const auto SOURCEFULLSCREENWINDOW = ORIGINALWORKSPACE ? getOverviewWindowToShow(Fullscreen::controller()->getFullscreenWindow(ORIGINALWORKSPACE)) : PHLWINDOW{};
-    const bool RESTORESOURCEFULLSCREENFOCUS = WINDOW && WINDOW->m_isFloating && MOVEWORKSPACE && shouldShowOverviewWindow(SOURCEFULLSCREENWINDOW) &&
+    const bool RESTORESOURCEFULLSCREENFOCUS = WINDOW && WINDOW->isFloating() && MOVEWORKSPACE && shouldShowOverviewWindow(SOURCEFULLSCREENWINDOW) &&
         SOURCEFULLSCREENWINDOW != WINDOW && SOURCEFULLSCREENWINDOW->m_workspace == ORIGINALWORKSPACE && Fullscreen::controller()->isFullscreen(SOURCEFULLSCREENWINDOW);
 
     const bool DROPSIDEHORIZONTAL = dropOverview->layout != ScrollOverview::Config::ELayout::HORIZONTAL || DROPSCROLLINGPRIMARYHORIZONTAL;
@@ -3153,7 +3153,7 @@ void CScrollOverview::endWindowDrag() {
             auto       GLOBALBOX  = dropWorkspaceFullyVisible ? CBox{dropOverview->overviewPointToGlobal(dropWorkspaceIdx, DRAGBOX.pos()), GLOBALSIZE} :
                                                                 centerBoxInWorkspace(CBox{Vector2D{}, GLOBALSIZE}, DROPWORKSPACE, DROPMONITOR);
             if (dropWorkspaceFullyVisible)
-                GLOBALBOX = clampBoxToWorkspace(GLOBALBOX, DROPWORKSPACE, DROPMONITOR, WINDOW->getRealBorderSize());
+                GLOBALBOX = clampBoxToWorkspace(GLOBALBOX, DROPWORKSPACE, DROPMONITOR, WINDOW->presentation().borderSize());
 
             TARGET->setPositionGlobal(GLOBALBOX);
             TARGET->warpPositionSize();
@@ -3170,7 +3170,7 @@ void CScrollOverview::endWindowDrag() {
         auto       GLOBALBOX  = CBox{GLOBALPOS, GLOBALSIZE};
         const auto WORKSPACE  = workspaceIdx < images.size() && images[workspaceIdx] ? images[workspaceIdx]->pWorkspace : WINDOW->m_workspace;
 
-        GLOBALBOX = clampBoxToWorkspace(GLOBALBOX, WORKSPACE, MONITOR, WINDOW->getRealBorderSize());
+        GLOBALBOX = clampBoxToWorkspace(GLOBALBOX, WORKSPACE, MONITOR, WINDOW->presentation().borderSize());
 
         TARGET->damageEntire();
         TARGET->setPositionGlobal(GLOBALBOX);
@@ -3215,7 +3215,7 @@ void CScrollOverview::endWindowResize() {
     const auto TARGET  = WINDOW ? WINDOW->layoutTarget() : nullptr;
     const auto MONITOR = pMonitor.lock();
 
-    if (WINDOW && TARGET && WINDOW->m_isFloating && resizeWorkspaceIdx < images.size()) {
+    if (WINDOW && TARGET && WINDOW->isFloating() && resizeWorkspaceIdx < images.size()) {
         const auto RESIZEDBOX  = resizedWindowBox();
         const auto SCALEFACTOR = std::max(scale->value(), 0.01F) * std::max(MONITOR ? MONITOR->m_scale : 1.F, 0.01F);
         auto       GLOBALBOX   = CBox{overviewPointToGlobal(resizeWorkspaceIdx, RESIZEDBOX.pos()), RESIZEDBOX.size() * (1.F / SCALEFACTOR)};
@@ -3512,9 +3512,9 @@ bool CScrollOverview::moveSelection(const std::string& direction) {
     if (!WORKSPACEIMAGE || !WORKSPACEIMAGE->pWorkspace)
         shouldMoveWorkspace = true;
 
-    if (!shouldMoveWorkspace && (!closeOnWindow || closeOnWindow->m_workspace != WORKSPACEIMAGE->pWorkspace || !shouldShowOverviewWindow(closeOnWindow.lock()) || closeOnWindow->m_isFloating)) {
+    if (!shouldMoveWorkspace && (!closeOnWindow || closeOnWindow->m_workspace != WORKSPACEIMAGE->pWorkspace || !shouldShowOverviewWindow(closeOnWindow.lock()) || closeOnWindow->isFloating())) {
         syncSelectionToViewport();
-        if (!closeOnWindow || closeOnWindow->m_workspace != WORKSPACEIMAGE->pWorkspace || !shouldShowOverviewWindow(closeOnWindow.lock()) || closeOnWindow->m_isFloating)
+        if (!closeOnWindow || closeOnWindow->m_workspace != WORKSPACEIMAGE->pWorkspace || !shouldShowOverviewWindow(closeOnWindow.lock()) || closeOnWindow->isFloating())
             shouldMoveWorkspace = true;
     }
 
@@ -3552,7 +3552,7 @@ bool CScrollOverview::moveSelection(const std::string& direction) {
 
     for (const auto& windowRef : shouldMoveWorkspace ? std::vector<PHLWINDOWREF>{} : WORKSPACEIMAGE->windows) {
         const auto WINDOW = getOverviewWindowToShow(windowRef.lock());
-        if (!shouldShowOverviewWindow(WINDOW) || WINDOW == CURRENT || WINDOW->m_isFloating)
+        if (!shouldShowOverviewWindow(WINDOW) || WINDOW == CURRENT || WINDOW->isFloating())
             continue;
 
         if (WINDOW->m_workspace != WORKSPACEIMAGE->pWorkspace || WINDOW->m_monitor != pMonitor)
@@ -3658,11 +3658,11 @@ void CScrollOverview::forceWindowSurfaceVisibility(PHLWINDOW window) {
 
     window->wlSurface()->resource()->breadthfirst([this](SP<CWLSurfaceResource> surface, const Vector2D&, void*) { forceSurfaceVisibility(surface); }, nullptr);
 
-    if (window->m_isX11 || !window->m_popupHead)
+    if (window->backend().isX11() || !window->popupHead())
         return;
 
-    window->m_popupHead->breadthfirst([this](WP<Desktop::View::CPopup> popup, void*) {
-        if (!popup || !popup->aliveAndVisible() || !popup->wlSurface() || !popup->wlSurface()->resource())
+    window->popupHead()->breadthfirst([this](SP<Desktop::View::CPopup> popup, void*) {
+        if (!popup || !popup->mapped() || !popup->wlSurface() || !popup->wlSurface()->resource())
             return;
 
         popup->wlSurface()->resource()->breadthfirst([this](SP<CWLSurfaceResource> surface, const Vector2D&, void*) { forceSurfaceVisibility(surface); }, nullptr);
@@ -3677,18 +3677,18 @@ void CScrollOverview::forceWindowVisible(PHLWINDOW window) {
 
     for (auto& entry : forcedWindowVisibility) {
         if (entry.window == window) {
-            window->m_hidden = false;
-            window->alpha(FULLSCREENALPHA)->setValueAndWarp(1.F);
+            window->setHidden(false);
+            window->presentation().alpha(FULLSCREENALPHA)->setValueAndWarp(1.F);
             return;
         }
     }
 
     auto& entry                  = forcedWindowVisibility.emplace_back();
     entry.window                 = window;
-    entry.hidden                 = window->m_hidden;
+    entry.hidden                 = window->isHidden();
 
-    window->m_hidden = false;
-    window->alpha(FULLSCREENALPHA)->setValueAndWarp(1.F);
+    window->setHidden(false);
+    window->presentation().alpha(FULLSCREENALPHA)->setValueAndWarp(1.F);
 }
 
 void CScrollOverview::forceLayersAboveFullscreen() {
@@ -3710,10 +3710,9 @@ void CScrollOverview::forceLayersAboveFullscreen() {
 
 			auto& lsAlpha = ls->alpha()[Desktop::View::LS_ALPHA_FADE];
             if (!known)
-                forcedLayerVisibility.push_back({ls, ls->m_aboveFullscreen, lsAlpha->value()});
+                forcedLayerVisibility.push_back({ls, bool(ls->m_flags & Desktop::View::LAYER_FLAG_ABOVE_FULLSCREEN), lsAlpha->value()});
 
-            if (!ls->m_aboveFullscreen)
-                ls->m_aboveFullscreen = true;
+            ls->m_flags |= Desktop::View::LAYER_FLAG_ABOVE_FULLSCREEN;
 
             if (lsAlpha->value() != 1.F || lsAlpha->goal() != 1.F || lsAlpha->isBeingAnimated())
                 lsAlpha->setValueAndWarp(1.F);
@@ -3747,15 +3746,15 @@ void CScrollOverview::restoreForcedWindowVisibility() {
 
         constexpr auto FULLSCREENALPHA = Desktop::View::WINDOW_ALPHA_FULLSCREEN;
         WINDOW->updateFullscreenInputState();
-        *WINDOW->alpha(FULLSCREENALPHA) = WINDOW->isBlockedByFullscreen() ? 0.F : 1.F;
+        *WINDOW->presentation().alpha(FULLSCREENALPHA) = WINDOW->isBlockedByFullscreen() ? 0.F : 1.F;
 
-        if (WINDOW->m_group) {
-            if (std::ranges::find(groupsToRefresh, WINDOW->m_group) == groupsToRefresh.end())
-                groupsToRefresh.emplace_back(WINDOW->m_group);
+        if (WINDOW->grouping().group()) {
+            if (std::ranges::find(groupsToRefresh, WINDOW->grouping().group()) == groupsToRefresh.end())
+                groupsToRefresh.emplace_back(WINDOW->grouping().group());
             continue;
         }
 
-        WINDOW->m_hidden = entry.hidden;
+        WINDOW->setHidden(entry.hidden);
     }
 
     for (const auto& group : groupsToRefresh) {
@@ -3771,7 +3770,10 @@ void CScrollOverview::restoreForcedLayerVisibility() {
         if (!entry.layer)
             continue;
 
-        entry.layer->m_aboveFullscreen = entry.aboveFullscreen;
+        if (entry.aboveFullscreen)
+            entry.layer->m_flags |= Desktop::View::LAYER_FLAG_ABOVE_FULLSCREEN;
+        else
+            entry.layer->m_flags &= ~Desktop::View::LAYER_FLAG_ABOVE_FULLSCREEN;
 
 		auto& entryLsAlpha = entry.layer->alpha()[Desktop::View::LS_ALPHA_FADE];
         const auto MONITOR = entry.layer->m_monitor.lock();
@@ -3781,7 +3783,7 @@ void CScrollOverview::restoreForcedLayerVisibility() {
         }
 
         const bool fullscreen = Fullscreen::controller()->hasFullscreen(MONITOR);
-        const bool visible    = !fullscreen || entry.layer->m_layer >= ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY || entry.layer->m_aboveFullscreen;
+        const bool visible    = !fullscreen || entry.layer->m_layer >= ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY || (entry.layer->m_flags & Desktop::View::LAYER_FLAG_ABOVE_FULLSCREEN);
         entryLsAlpha->setValueAndWarp(visible ? 1.F : 0.F);
     }
 
@@ -4078,7 +4080,7 @@ void CScrollOverview::renderWorkspaceLive(PHLMONITOR monitor, size_t workspaceId
             .anchor                = ANCHOR,
             .renderScale           = renderScale,
             .workspaceFullyVisible = overviewBoxFullyVisibleOnMonitor(WORKSPACEBOX, monitor),
-            .floating              = DRAGGED->m_isFloating,
+            .floating              = DRAGGED->isFloating(),
             .layout                = layout,
         });
     };
@@ -4088,7 +4090,7 @@ void CScrollOverview::renderWorkspaceLive(PHLMONITOR monitor, size_t workspaceId
         OverviewRender::flushPass(monitor);
         for (const auto& windowRef : workspaceImage->windows) {
             const auto window = getOverviewWindowToShow(windowRef.lock());
-            if (!shouldShowOverviewWindow(window) || !window->m_isFloating || window == fullscreenWindow)
+            if (!shouldShowOverviewWindow(window) || !window->isFloating() || window == fullscreenWindow)
                 continue;
 
             renderOverviewWindow(window);
@@ -4100,7 +4102,7 @@ void CScrollOverview::renderWorkspaceLive(PHLMONITOR monitor, size_t workspaceId
     const auto renderWindowsByState = [&](bool floating) {
         for (const auto& windowRef : workspaceImage->windows) {
             const auto window = getOverviewWindowToShow(windowRef.lock());
-            if (!window || window->m_isFloating != floating)
+            if (!window || window->isFloating() != floating)
                 continue;
 
             renderOverviewWindow(window);
@@ -4502,7 +4504,7 @@ bool CScrollOverview::shouldSuppressRenderDamage() const {
 
                 for (const auto& windowRef : workspaceImage->windows) {
                     const auto window = getOverviewWindowToShow(windowRef.lock());
-                    if (window && window->m_isFloating && isVisibleAnimatedWindow(window, WORKSPACEOFFSET))
+                    if (window && window->isFloating() && isVisibleAnimatedWindow(window, WORKSPACEOFFSET))
                         return false;
                 }
 
@@ -4597,7 +4599,7 @@ void CScrollOverview::sendOverviewFrameCallbacks(const Time::steady_tp& now) {
                 frameWindow(fullscreenWindow, WORKSPACEOFFSET, REALTIME);
                 for (const auto& windowRef : workspaceImage->windows) {
                     const auto window = getOverviewWindowToShow(windowRef.lock());
-                    if (window && window->m_isFloating)
+                    if (window && window->isFloating())
                         frameWindow(window, WORKSPACEOFFSET, REALTIME);
                 }
                 continue;
@@ -4682,7 +4684,7 @@ bool CScrollOverview::shouldAllowSurfaceFrame(SP<CWLSurfaceResource> surface, co
 
         if (!isWorkspaceScrolling(workspaceImage->pWorkspace)) {
             const auto fullscreenWindow = getOverviewWindowToShow(Fullscreen::controller()->getFullscreenWindow(workspaceImage->pWorkspace));
-            if (shouldShowOverviewWindow(fullscreenWindow) && fullscreenWindow->m_workspace == workspaceImage->pWorkspace && fullscreenWindow != window && !window->m_isFloating)
+            if (shouldShowOverviewWindow(fullscreenWindow) && fullscreenWindow->m_workspace == workspaceImage->pWorkspace && fullscreenWindow != window && !window->isFloating())
                 return false;
         }
 
@@ -4782,7 +4784,7 @@ bool CScrollOverview::shouldHandleSurfaceDamage(SP<CWLSurfaceResource> surface) 
 
         if (!isWorkspaceScrolling(workspaceImage->pWorkspace)) {
             const auto fullscreenWindow = getOverviewWindowToShow(Fullscreen::controller()->getFullscreenWindow(workspaceImage->pWorkspace));
-            if (shouldShowOverviewWindow(fullscreenWindow) && fullscreenWindow->m_workspace == workspaceImage->pWorkspace && fullscreenWindow != window && !window->m_isFloating)
+            if (shouldShowOverviewWindow(fullscreenWindow) && fullscreenWindow->m_workspace == workspaceImage->pWorkspace && fullscreenWindow != window && !window->isFloating())
                 return false;
         }
 


### PR DESCRIPTION
## Context

Current git Hyprland (0.56, 2026-08-18 `9d4f7a8`) split `CWindow` again:

- `#include <hyprland/src/desktop/view/Window.hpp>` → `desktop/view/window/Window.hpp`
- `m_group` / `m_groupRules` → `grouping().group()` / `grouping().rules()`
- `m_pinned` → `m_state & WINDOW_STATE_PINNED`
- `m_isFloating` → `isFloating()`
- `rounding()`, `getRealBorderSize()`, `m_windowDecorations`, `alpha(eWindowAlpha)`, dim/offset/animatingIn → `presentation()`
- `m_realBorderColor` / `m_realShadowColor` / fade animations → decoration `CAnimatedDecorationGradient`
- `m_isX11` / `m_X11DoesntWantBorders` / `getReportedSize` / `m_xdgSurface` → `backend()`
- `m_hidden` → `setHidden()` / `isHidden()`
- `CLayerSurface::m_aboveFullscreen` → `LAYER_FLAG_ABOVE_FULLSCREEN`
- popup `aliveAndVisible()` / `WP` breadthfirst → `mapped()` / `SP`

`new-release` therefore no longer builds against current Hyprland.

## Changes

- Update include paths
- Move window state, decoration, alpha, group, X11, popup, and layer calls to the new APIs
- Overview pseudo-focus now temporarily changes `FocusState` and calls decoration `updateState()`, instead of writing removed color fields

## Verification

Based on `new-release` (`7e677f2`), built against the Hyprland pin `9d4f7a83ce2764ddb51b4ea01f8ae1e6f1c18f66`:

- `nix-build` of the plugin succeeded (`libscrolloverview.so`)
- Only the existing `addConfigKeyword` deprecation warning remains