### PR TITLE
fix: adapt blur APIs for Hyprland 0.56

### DIFF
--- a/Window.cpp
+++ b/Window.cpp
@@ -951,7 +951,7 @@ static SOverviewCustomDecorationRenderState renderOverviewCustomDecorations(PHLM
 } // namespace
 
 bool shouldBlurBackground(const PHLWINDOW& window) {
-    return window && g_pHyprRenderer && g_pHyprRenderer->shouldBlur(window);
+    return window && window->shouldBlur();
 }
 
 static bool overviewBoxContains(const CBox& outer, const CBox& inner) {

--- a/scrollOverview.cpp
+++ b/scrollOverview.cpp
@@ -1704,7 +1704,8 @@ void CScrollOverview::updateBackdropBlurCache(PHLMONITOR monitor, int wallpaperM
     SP<Render::ITexture> BLURREDTEX;
     {
         auto bindBackdrop = g_pHyprRenderer->bindTempFB(backdropBlurFB);
-        BLURREDTEX        = g_pHyprRenderer->blurMainFramebuffer(1.F, &blurDamage);
+        const auto blurredFB = g_pHyprRenderer->blurMainFramebuffer(1.F, blurDamage);
+        BLURREDTEX = blurredFB ? blurredFB->getTexture() : nullptr;
     }
     if (!BLURREDTEX || !BLURREDTEX->m_size.x || !BLURREDTEX->m_size.y)
         return;


### PR DESCRIPTION
Hyprland 0.56 changed two renderer APIs used by the plugin.

Changes:
- use `CWindow::shouldBlur()` instead of the removed renderer `shouldBlur(window)` API
- pass `CRegion` by reference to `blurMainFramebuffer()`
- convert the returned `IFramebuffer` to its texture with `getTexture()`

Built successfully against Hyprland 0.56.0 and tested after rebooting.