### PR TITLE
feat: add cross-monitor window dragging

### DIFF
--- a/Config.cpp
+++ b/Config.cpp
@@ -274,6 +274,8 @@ static void registerConfigValues() {
     HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE,
                                   makeShared<CStringValue>("plugin:scrolloverview:layout", "overview layout", Hyprlang::STRING{"vertical"}));
     HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE,
+                                  makeShared<CBoolValue>("plugin:scrolloverview:cross_monitor_drag", "enable cross-monitor window dragging", false));
+    HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE,
                                   makeShared<CIntValue>("plugin:scrolloverview:input:scroll_event_delay", "minimum delay (ms) between discrete scroll steps (wheel workspace nav and trackpad focus stepping)", 200, SIntValueOptions{.min = 0}));
     HyprlandAPI::addConfigValueV2(SCROLLOVERVIEW_HANDLE,
                                   makeShared<CFloatValue>("plugin:scrolloverview:input:touchpad_scroll_factor", "overview touchpad scroll factor", 1.F,
@@ -323,7 +325,14 @@ int getWorkspaceGap() {
 
 ELayout getLayout() {
     const auto LAYOUT = getValue<std::string>("plugin:scrolloverview:layout");
+    if (LAYOUT == "auto")
+        return ELayout::AUTO;
+
     return LAYOUT == "horizontal" ? ELayout::HORIZONTAL : ELayout::VERTICAL;
+}
+
+bool getCrossMonitorDrag() {
+    return getValue<bool>("plugin:scrolloverview:cross_monitor_drag");
 }
 
 bool getLeftHanded() {

--- a/Config.hpp
+++ b/Config.hpp
@@ -21,6 +21,7 @@ using TGestureRegistrar   = SDispatchResult (*)(size_t fingerCount, const std::s
 enum class ELayout {
     VERTICAL,
     HORIZONTAL,
+    AUTO,
 };
 
 enum class EScrollAction {
@@ -87,6 +88,7 @@ int           getGestureDistance();
 float         getScale();
 int           getWorkspaceGap();
 ELayout       getLayout();
+bool          getCrossMonitorDrag();
 int           getScrollEventDelay();
 bool          getLeftHanded();
 int           getDragMode();

--- a/IOverview.hpp
+++ b/IOverview.hpp
@@ -31,6 +31,7 @@ class IOverview {
     virtual void  onSwipeEnd()                = 0;
 
     virtual void  close()                  = 0;
+    virtual void  dismissTransient()                                = 0;
     virtual bool  isClosing() const        = 0;
     virtual void  reopen()                 = 0;
     virtual void  selectHoveredWorkspace() = 0;
@@ -53,6 +54,9 @@ void                              closeAll();
 void                              registerScrollOverview(const SP<IOverview>& overview);
 void                              unregisterScrollOverview(IOverview* overview);
 void                              clearScrollOverviews();
+void                              markCrossMonitorDragSession(IOverview* source, const SP<IOverview>& destination);
+bool                              closeCrossMonitorDragSession();
+void                              removeFromCrossMonitorDragSession(IOverview* overview);
 
 // Current interaction/render context. The authoritative state is the registry.
 inline SP<IOverview> g_pScrollOverview;

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 .PHONY: all clean FORCE
 
 all: $(VERSION_HEADER)
-	$(CXX) -shared -fPIC $(EXTRA_FLAGS) -I.build main.cpp Config.cpp DropIndicator.cpp OverviewGesture.cpp OverviewManager.cpp OverviewPassElement.cpp OverviewRender.cpp Window.cpp scrollOverview.cpp -o scrolloverview.so -g `pkg-config --cflags pixman-1 libdrm hyprland pangocairo libinput libudev wayland-server xkbcommon '$(LUA_PKG) >= 5.4'` -std=c++2b -Wno-narrowing
+	$(CXX) -shared -fPIC $(EXTRA_FLAGS) -I.build main.cpp Config.cpp DropIndicator.cpp NativeDrag.cpp OverviewGesture.cpp OverviewManager.cpp OverviewPassElement.cpp OverviewRender.cpp Window.cpp scrollOverview.cpp -o scrolloverview.so -g `pkg-config --cflags pixman-1 libdrm hyprland pangocairo libinput libudev wayland-server xkbcommon '$(LUA_PKG) >= 5.4'` -std=c++2b -Wno-narrowing
 
 $(VERSION_HEADER): FORCE $(VERSION_SCRIPT)
 	sh $(VERSION_SCRIPT) $@ .

--- a/NativeDrag.cpp
+++ b/NativeDrag.cpp
@@ -1,0 +1,14 @@
+#include <any>
+#include <chrono>
+#include <sstream>
+
+#define private public
+#include <hyprland/src/layout/supplementary/DragController.hpp>
+#undef private
+
+#include "NativeDrag.hpp"
+
+void finishNativeDragAdoption(Layout::Supplementary::CDragStateController* dragController) {
+    if (dragController)
+        dragController->m_dragMode = MBIND_INVALID;
+}

--- a/NativeDrag.hpp
+++ b/NativeDrag.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace Layout::Supplementary {
+    class CDragStateController;
+}
+
+void finishNativeDragAdoption(Layout::Supplementary::CDragStateController* dragController);

--- a/OverviewGesture.cpp
+++ b/OverviewGesture.cpp
@@ -1,6 +1,7 @@
 #include "OverviewGesture.hpp"
 
 #include "scrollOverview.hpp"
+#include "OverviewOpen.hpp"
 
 #include <algorithm>
 #include <hyprland/src/Compositor.hpp>
@@ -17,15 +18,11 @@ void COverviewGesture::begin(const ITrackpadGesture::STrackpadGestureBegin& e) {
     if (!MONITOR)
         return;
 
-    auto       overview = scrollOverviewForMonitor(MONITOR);
+    const auto [overview, created] = openOverview(MONITOR, true);
+    if (!overview)
+        return;
 
-    if (!overview) {
-        if (!ensureScrollOverviewHooks())
-            return;
-
-        overview = makeShared<CScrollOverview>(MONITOR->m_activeWorkspace, true, MONITOR);
-        registerScrollOverview(overview);
-    } else {
+    if (!created) {
         overview->selectHoveredWorkspace();
         overview->setClosing(true);
     }

--- a/OverviewManager.cpp
+++ b/OverviewManager.cpp
@@ -6,6 +6,17 @@
 #include <hyprland/src/output/Monitor.hpp>
 
 static std::vector<SP<IOverview>> g_scrollOverviews;
+static std::vector<WP<IOverview>> g_crossMonitorDragSession;
+
+static void pruneCrossMonitorDragSession() {
+    std::erase_if(g_crossMonitorDragSession, [](const auto& ref) {
+        const auto overview = ref.lock();
+        return !overview || std::ranges::find(g_scrollOverviews, overview) == g_scrollOverviews.end();
+    });
+
+    if (g_crossMonitorDragSession.size() < 2)
+        g_crossMonitorDragSession.clear();
+}
 
 const std::vector<SP<IOverview>>& scrollOverviews() {
     return g_scrollOverviews;
@@ -61,13 +72,65 @@ void unregisterScrollOverview(IOverview* overview) {
     if (!overview)
         return;
 
+    removeFromCrossMonitorDragSession(overview);
     std::erase_if(g_scrollOverviews, [overview](const auto& candidate) { return candidate.get() == overview; });
     g_pScrollOverview = activeScrollOverview();
 }
 
 void clearScrollOverviews() {
+    g_crossMonitorDragSession.clear();
     auto overviews = std::move(g_scrollOverviews);
     g_scrollOverviews.clear();
     g_pScrollOverview.reset();
     overviews.clear();
+}
+
+void markCrossMonitorDragSession(IOverview* source, const SP<IOverview>& destination) {
+    if (!source || !destination || source == destination.get())
+        return;
+
+    pruneCrossMonitorDragSession();
+
+    const auto SOURCE = std::ranges::find_if(g_scrollOverviews, [source](const auto& overview) { return overview.get() == source; });
+    if (SOURCE == g_scrollOverviews.end() || std::ranges::find(g_scrollOverviews, destination) == g_scrollOverviews.end())
+        return;
+
+    const bool SOURCEINSESSION = std::ranges::any_of(g_crossMonitorDragSession, [source](const auto& ref) { return ref.lock().get() == source; });
+    if (!SOURCEINSESSION)
+        g_crossMonitorDragSession = {WP<IOverview>{*SOURCE}};
+
+    const bool DESTINATIONINSESSION = std::ranges::any_of(g_crossMonitorDragSession, [&destination](const auto& ref) { return ref.lock() == destination; });
+    if (!DESTINATIONINSESSION)
+        g_crossMonitorDragSession.emplace_back(destination);
+}
+
+bool closeCrossMonitorDragSession() {
+    pruneCrossMonitorDragSession();
+    if (g_crossMonitorDragSession.empty())
+        return false;
+
+    std::vector<SP<IOverview>> members;
+    members.reserve(g_crossMonitorDragSession.size());
+    for (const auto& ref : g_crossMonitorDragSession) {
+        if (const auto overview = ref.lock())
+            members.emplace_back(overview);
+    }
+
+    for (const auto& overview : members)
+        overview->close();
+
+    pruneCrossMonitorDragSession();
+    return true;
+}
+
+void removeFromCrossMonitorDragSession(IOverview* overview) {
+    if (!overview)
+        return;
+
+    std::erase_if(g_crossMonitorDragSession, [overview](const auto& ref) {
+        const auto member = ref.lock();
+        return !member || member.get() == overview || std::ranges::find(g_scrollOverviews, member) == g_scrollOverviews.end();
+    });
+    if (g_crossMonitorDragSession.size() < 2)
+        g_crossMonitorDragSession.clear();
 }

--- a/OverviewOpen.hpp
+++ b/OverviewOpen.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "IOverview.hpp"
+
+struct SOverviewOpenResult {
+    SP<IOverview> overview;
+    bool          created = false;
+};
+
+SOverviewOpenResult openOverview(PHLMONITOR monitor, bool swipe = false);
+bool                adoptNativeWindowDragIntoOverview();

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ plugin {
         gesture_distance = 300 # how far is the "max" for the gesture
         scale = 0.5 # preferred overview scale
         workspace_gap = 100
-        layout = vertical # vertical or horizontal
+        layout = vertical # vertical, horizontal, or auto (per-monitor orientation)
         wallpaper = 2 # 0: global only, 1: per-workspace only, 2: both
         blur = true # blur only the main overview wallpaper
 
@@ -64,7 +64,7 @@ hl.config({
             gesture_distance = 300, -- how far is the "max" for the gesture
             scale = 0.5, -- preferred overview scale
             workspace_gap = 100,
-            layout = "vertical", -- vertical or horizontal
+            layout = "vertical", -- vertical, horizontal, or auto (per-monitor orientation)
             wallpaper = 2, -- 0: global only, 1: per-workspace only, 2: both
             blur = true, -- blur only the main overview wallpaper
 
@@ -81,6 +81,10 @@ hl.bind("SUPER + g", function()
     hl.plugin.scrolloverview.overview("toggle all")
 end)
 ```
+
+Set `cross_monitor_drag = true` to drag windows between monitors through ScrollOverview and adopt Hyprland move drags when another overview is open. It defaults to `false`. Native adoption uses Hyprland internals; if unavailable, overview-origin cross-monitor dragging still works.
+
+This setting does not affect overview-origin drags with `toggle all` because every overview is already open. Existing multi-monitor commands remain available when it is disabled.
 
 ## Documentation
 

--- a/docs/wiki/Basic-configuration.md
+++ b/docs/wiki/Basic-configuration.md
@@ -10,7 +10,7 @@ hl.config({
             gesture_distance = 300, -- how far is the "max" for the gesture
             scale = 0.5, -- preferred overview scale
             workspace_gap = 100,
-            layout = "vertical", -- vertical or horizontal
+            layout = "vertical", -- vertical, horizontal, or auto (per-monitor orientation)
             wallpaper = 2, -- 0: global only, 1: per-workspace only, 2: both
             blur = true, -- blur only the main overview wallpaper
 
@@ -35,7 +35,8 @@ end)
 | gesture_distance | number | how far is the max for the gesture | `200` |
 | scale | float | overview scale, [0.1–0.9] | `0.5` |
 | workspace_gap | number | gap between visible workspaces in the overview, in pixels | `0` |
-| layout | string | overview layout: `vertical` or `horizontal` | `vertical` |
+| layout | string | overview layout: `vertical`, `horizontal`, or `auto`; auto uses horizontal on portrait monitors and vertical on landscape monitors | `vertical` |
+| cross_monitor_drag | bool | enable cross-monitor overview dragging and Hyprland move-drag adoption; does not affect `open all`, `toggle all`, or manually opened overviews | `false` |
 | wallpaper | int | wallpaper mode: `0` global only, `1` per-workspace only, `2` both | `0` |
 | blur | bool | blur the main overview wallpaper without blurring workspace wallpapers | `false` |
 | input | structure | input configuration subcategory; accepts a structure containing the properties listed below | see below |

--- a/docs/wiki/Keybind-submap.md
+++ b/docs/wiki/Keybind-submap.md
@@ -29,4 +29,10 @@ for i = 1, 10 do
 end
 ```
 
+For native drag adoption with `cross_monitor_drag = true`, add this optional submap bind:
+
+```lua
+hl.bind("SUPER + mouse:272", hl.dsp.window.drag(), { mouse = true })
+```
+
 [Back to Configuration](Configuration.md)

--- a/main.cpp
+++ b/main.cpp
@@ -15,6 +15,7 @@
 #include <hyprland/src/render/Renderer.hpp>
 #include <hyprland/src/state/MonitorState.hpp>
 #include <hyprland/src/managers/input/trackpad/GestureTypes.hpp>
+#include <hyprutils/utils/ScopeGuard.hpp>
 #include <hyprland/src/managers/input/trackpad/TrackpadGestures.hpp>
 
 #include <hyprutils/string/ConstVarList.hpp>
@@ -25,6 +26,7 @@ using namespace Hyprutils::String;
 #include "PluginVersion.hpp"
 #include "scrollOverview.hpp"
 #include "OverviewGesture.hpp"
+#include "OverviewOpen.hpp"
 
 // Methods
 static CFunctionHook* g_pScrollRenderWorkspaceHook = nullptr;
@@ -34,6 +36,7 @@ static CFunctionHook* g_pScrollDamageSurfaceHook   = nullptr;
 static CFunctionHook* g_pScrollScheduleFrameHook   = nullptr;
 static CFunctionHook* g_pScrollSendFrameEventsHook = nullptr;
 static CFunctionHook* g_pScrollSurfaceFrameHook    = nullptr;
+static CFunctionHook* g_pScrollMoveMouseHook       = nullptr;
 typedef void (*origRenderWorkspace)(void*, PHLMONITOR, PHLWORKSPACE, const Time::steady_tp&, const CBox&);
 typedef void (*origAddDamageA)(void*, const CBox&);
 typedef void (*origAddDamageB)(void*, const pixman_region32_t*);
@@ -41,6 +44,7 @@ typedef void (*origDamageSurface)(void*, SP<CWLSurfaceResource>, double, double,
 typedef void (*origScheduleFrame)(void*, Aquamarine::IOutput::scheduleFrameReason);
 typedef void (*origSendFrameEventsToWorkspace)(void*, PHLMONITOR, PHLWORKSPACE, const Time::steady_tp&);
 typedef void (*origSurfaceFrame)(void*, const Time::steady_tp&);
+typedef void (*origMoveMouse)(void*, const Vector2D&);
 
 static bool g_unloading = false;
 
@@ -52,9 +56,16 @@ APICALL EXPORT std::string PLUGIN_API_VERSION() {
 static bool renderingOverview = false;
 static bool damageFromSurface = false;
 static PHLMONITORREF renderingOverviewMonitor;
-static bool g_scrollOverviewHooksActive = false;
+static bool                g_scrollOverviewHooksActive      = false;
+static bool                g_scrollMoveMouseHookActive      = false;
+static bool                g_scrollMoveMouseHookUnavailable = false;
+static bool                g_scrollMoveMouseHookWarned      = false;
+static CHyprSignalListener g_configReloadHook;
 
 static void failNotif(const std::string& reason);
+static void warnNativeDragUnavailable();
+static void disableNativeDragHook();
+static void reconcileNativeDragHook();
 
 bool ensureScrollOverviewHooks() {
     if (g_scrollOverviewHooksActive)
@@ -75,10 +86,12 @@ bool ensureScrollOverviewHooks() {
     }
 
     g_scrollOverviewHooksActive = true;
+    reconcileNativeDragHook();
     return true;
 }
 
 void disableScrollOverviewHooks() {
+    disableNativeDragHook();
     if (g_pScrollAddDamageHookB)
         g_pScrollAddDamageHookB->unhook();
     if (g_pScrollAddDamageHookA)
@@ -95,6 +108,19 @@ void disableScrollOverviewHooks() {
         g_pScrollRenderWorkspaceHook->unhook();
 
     g_scrollOverviewHooksActive = false;
+}
+
+static void hkMoveMouse(void* thisptr, const Vector2D& mousePos) {
+    rc<origMoveMouse>(g_pScrollMoveMouseHook->m_original)(thisptr, mousePos);
+
+    // moveMouse() updates dragThresholdReached().
+    if (!g_unloading && g_scrollMoveMouseHookActive && ScrollOverview::Config::getCrossMonitorDrag()) {
+        try {
+            adoptNativeWindowDragIntoOverview();
+        } catch (...) {
+            // Never unwind through a Hyprland hook.
+        }
+    }
 }
 
 static void hkScheduleFrame(void* thisptr, Aquamarine::IOutput::scheduleFrameReason reason) {
@@ -233,19 +259,55 @@ static SP<IOverview> dispatcherOverview() {
     return activeScrollOverview();
 }
 
-static bool openOverview(PHLMONITOR monitor) {
-    if (!monitor || scrollOverviewForMonitor(monitor))
-        return true;
+bool adoptNativeWindowDragIntoOverview() {
+    if (!ScrollOverview::Config::getCrossMonitorDrag() || scrollOverviews().empty() || !g_layoutManager || !g_pInputManager)
+        return false;
+
+    const auto& DRAGCONTROLLER = g_layoutManager->dragController();
+    const auto  TARGET         = DRAGCONTROLLER ? DRAGCONTROLLER->target() : nullptr;
+    const auto  WINDOW         = TARGET ? TARGET->window() : PHLWINDOW{};
+    if (!WINDOW || DRAGCONTROLLER->mode() != MBIND_MOVE || !DRAGCONTROLLER->dragThresholdReached())
+        return false;
+
+    const auto SOURCEWORKSPACE = TARGET->workspace();
+    const auto SOURCEMONITOR   = SOURCEWORKSPACE ? SOURCEWORKSPACE->m_monitor.lock() : WINDOW->m_monitor.lock();
+    if (!SOURCEMONITOR || !SOURCEMONITOR->m_enabled)
+        return false;
+
+    auto        result   = openOverview(SOURCEMONITOR);
+    if (result.overview && result.overview->isClosing())
+        result.overview->reopen();
+
+    auto* const overview = result.overview ? dynamic_cast<CScrollOverview*>(result.overview.get()) : nullptr;
+    if (!overview || !overview->adoptNativeWindowDrag(WINDOW)) {
+        if (result.created && result.overview)
+            result.overview->dismissTransient();
+        return false;
+    }
+
+    result.overview->requestInputFrame();
+    result.overview->damage();
+    return true;
+}
+
+SOverviewOpenResult openOverview(PHLMONITOR monitor, bool swipe) {
+    if (!monitor)
+        return {};
+
+    if (const auto OVERVIEW = scrollOverviewForMonitor(monitor))
+        return {.overview = OVERVIEW, .created = false};
 
     if (!ensureScrollOverviewHooks())
-        return false;
+        return {};
 
     const bool PREVRENDERINGOVERVIEW = renderingOverview;
     renderingOverview                = true;
-    auto overview                    = makeShared<CScrollOverview>(monitor->m_activeWorkspace, false, monitor);
+    auto restoreRenderingOverview    = Hyprutils::Utils::CScopeGuard([PREVRENDERINGOVERVIEW] { renderingOverview = PREVRENDERINGOVERVIEW; });
+
+    auto overview = makeShared<CScrollOverview>(monitor->m_activeWorkspace, swipe, monitor);
     registerScrollOverview(overview);
-    renderingOverview = PREVRENDERINGOVERVIEW;
-    return true;
+    reconcileNativeDragHook();
+    return {.overview = overview, .created = true};
 }
 
 static SDispatchResult onOverviewDispatcher(std::string arg) {
@@ -282,6 +344,9 @@ static SDispatchResult onOverviewDispatcher(std::string arg) {
     if (ACTION != "toggle" && ACTION != "on" && ACTION != "open" && ACTION != "enable")
         return {.success = false, .error = "invalid arg. expected toggle|open|close|select [monitor|all]"};
 
+    if (ACTION == "toggle" && TARGET.empty() && closeCrossMonitorDragSession())
+        return {};
+
     const auto MONITORS = overviewTargetMonitors(TARGET);
     if (MONITORS.empty())
         return {.success = false, .error = TARGET.empty() ? "no active monitor" : "monitor not found: " + TARGET};
@@ -300,7 +365,7 @@ static SDispatchResult onOverviewDispatcher(std::string arg) {
     }
 
     for (const auto& monitor : MONITORS) {
-        if (!openOverview(monitor))
+        if (!openOverview(monitor).overview)
             return {.success = false, .error = "failed enabling overview hooks (is other overview plugin enabled?)"};
     }
     return {};
@@ -333,6 +398,77 @@ static SDispatchResult onWindowDispatcher(std::string arg) {
 
 static void failNotif(const std::string& reason) {
     HyprlandAPI::addNotification(SCROLLOVERVIEW_HANDLE, "[scrolloverview] Failure in initialization: " + reason, CHyprColor{1.0, 0.2, 0.2, 1.0}, 5000);
+}
+
+static void warnNativeDragUnavailable() {
+    if (g_scrollMoveMouseHookWarned)
+        return;
+
+    g_scrollMoveMouseHookWarned = true;
+    HyprlandAPI::addNotification(
+        SCROLLOVERVIEW_HANDLE,
+        "[scrolloverview] cross-monitor drag is enabled, but Hyprland drag adoption is unavailable; overview-origin cross-monitor dragging remains available",
+        CHyprColor{1.0, 0.75, 0.2, 1.0}, 7500);
+}
+
+static void disableNativeDragHook() {
+    if (!g_scrollMoveMouseHookActive)
+        return;
+
+    if (g_pScrollMoveMouseHook && g_pScrollMoveMouseHook->unhook())
+        g_scrollMoveMouseHookActive = false;
+}
+
+static void* findOptionalFn(const std::string& name, const std::string_view demangledNeedle) {
+    try {
+        const auto FNS = HyprlandAPI::findFunctionsByName(SCROLLOVERVIEW_HANDLE, name);
+        std::vector<SFunctionMatch> matches;
+        matches.reserve(FNS.size());
+        for (const auto& fn : FNS) {
+            if (fn.demangled.find(demangledNeedle) != std::string::npos)
+                matches.emplace_back(fn);
+        }
+
+        return matches.size() == 1 ? matches.front().address : nullptr;
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+static void reconcileNativeDragHook() {
+    const bool REQUESTED = !g_unloading && g_scrollOverviewHooksActive && !scrollOverviews().empty() && ScrollOverview::Config::getCrossMonitorDrag();
+
+    if (!REQUESTED) {
+        disableNativeDragHook();
+        return;
+    }
+
+    if (g_scrollMoveMouseHookActive)
+        return;
+
+    try {
+        if (!g_pScrollMoveMouseHook && !g_scrollMoveMouseHookUnavailable) {
+            const auto ADDRESS = findOptionalFn("moveMouse", "CLayoutManager::moveMouse(");
+            if (ADDRESS)
+                g_pScrollMoveMouseHook = HyprlandAPI::createFunctionHook(SCROLLOVERVIEW_HANDLE, ADDRESS, rc<void*>(hkMoveMouse));
+
+            if (!g_pScrollMoveMouseHook)
+                g_scrollMoveMouseHookUnavailable = true;
+        }
+
+        if (!g_scrollMoveMouseHookUnavailable && g_pScrollMoveMouseHook) {
+            if (g_pScrollMoveMouseHook->hook()) {
+                g_scrollMoveMouseHookActive = true;
+                return;
+            }
+
+            g_scrollMoveMouseHookUnavailable = true;
+        }
+    } catch (...) {
+        g_scrollMoveMouseHookUnavailable = true;
+    }
+
+    warnNativeDragUnavailable();
 }
 
 // Helper function to find a function by name and ensure it contains one of the requested substrings in its demangled name (to disambiguate overloads).
@@ -523,6 +659,8 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
             overview->onPreRender();
     });
 
+    g_configReloadHook = Event::bus()->m_events.config.reloaded.listen([] { reconcileNativeDragHook(); });
+
     ScrollOverview::Config::registerDispatcher("overview", ::onOverviewDispatcher);
     ScrollOverview::Config::registerDispatcher("navigate", ::onNavigateDispatcher);
     ScrollOverview::Config::registerDispatcher("window", ::onWindowDispatcher);
@@ -536,6 +674,7 @@ APICALL EXPORT void PLUGIN_EXIT() {
     g_pHyprRenderer->m_renderPass.removeAllOfType("CScrollOverviewPassElement");
 
     g_unloading = true;
+    g_configReloadHook.reset();
     clearScrollOverviews();
     disableScrollOverviewHooks();
 

--- a/scrollOverview.cpp
+++ b/scrollOverview.cpp
@@ -63,6 +63,8 @@
 #undef private
 #include "Config.hpp"
 #include "DropIndicator.hpp"
+#include "NativeDrag.hpp"
+#include "OverviewOpen.hpp"
 #include "OverviewPassElement.hpp"
 #include "OverviewRender.hpp"
 #include "Window.hpp"
@@ -71,6 +73,7 @@ static PHLWINDOW getOverviewFullscreenVisibilityWindow(const PHLWORKSPACE& works
 static constexpr const char* OVERVIEW_SUBMAP = "scrolloverview";
 static constexpr auto        POST_DROP_PSEUDO_FOCUS_DURATION = std::chrono::milliseconds(100);
 static CScrollOverview*             g_pointerGrabOverview = nullptr;
+static bool                         g_finishingAdoptedNativeDrag    = false;
 static std::unordered_set<uint32_t> g_topLayerPointerButtons;
 static PHLWINDOWREF                 g_pseudoFocusedWindow;
 static Time::steady_tp              g_pseudoFocusUntil = {};
@@ -946,6 +949,7 @@ static void moveOverviewTargetNextToWindow(const SP<Layout::ITarget>& target, co
 }
 
 CScrollOverview::~CScrollOverview() {
+    cancelWindowDrag();
     if (g_pointerGrabOverview == this)
         g_pointerGrabOverview = nullptr;
     transferSharedStateOwnership();
@@ -980,6 +984,8 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_, PHLMONITO
     const auto          PMONITOR = monitor_ ? monitor_ : (startedOn_ && startedOn_->m_monitor ? startedOn_->m_monitor.lock() : Desktop::focusState()->monitor());
     pMonitor                     = PMONITOR;
     layout                       = ScrollOverview::Config::getLayout();
+    if (layout == ScrollOverview::Config::ELayout::AUTO)
+        layout = PMONITOR && PMONITOR->logicalBox().height > PMONITOR->logicalBox().width ? ScrollOverview::Config::ELayout::HORIZONTAL : ScrollOverview::Config::ELayout::VERTICAL;
     sharedStateOwner             = scrollOverviews().empty();
     usesSubmapKeybinds           = hasOverviewSubmap();
 
@@ -1038,6 +1044,11 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_, PHLMONITO
 
         if (closing || (g_pointerGrabOverview && g_pointerGrabOverview != this) || (!g_pointerGrabOverview && INPUTOVERVIEW.get() != this))
             return;
+
+        if (dragCancelledAwaitingRelease) {
+            info.cancelled = true;
+            return;
+        }
 
         const bool     LEFT_HANDED           = ScrollOverview::Config::getLeftHanded();
         const uint32_t MAIN_BUTTON           = LEFT_HANDED ? BTN_RIGHT : BTN_LEFT;
@@ -1142,19 +1153,50 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_, PHLMONITO
 
         const bool FORWARDEDTOPLAYERRELEASE =
             event.state == WL_POINTER_BUTTON_STATE_RELEASED && g_topLayerPointerButtons.contains(event.button);
+        const bool ADOPTEDNATIVEDRAGRELEASE = dragAdoptedFromNative && g_pointerGrabOverview == this && event.state == WL_POINTER_BUTTON_STATE_RELEASED;
+        const bool CANCELLEDGRABRELEASE = closing && dragCancelledAwaitingRelease && g_pointerGrabOverview == this && event.state == WL_POINTER_BUTTON_STATE_RELEASED;
         const auto INPUTOVERVIEW = scrollOverviewAt(g_pInputManager->getMouseCoordsInternal());
-        if (closing || (g_pointerGrabOverview && g_pointerGrabOverview != this) ||
+        if ((closing && !CANCELLEDGRABRELEASE) || (g_pointerGrabOverview && g_pointerGrabOverview != this) ||
             (!g_pointerGrabOverview && INPUTOVERVIEW.get() != this && !FORWARDEDTOPLAYERRELEASE))
             return;
 
+        if (dragCancelledAwaitingRelease && event.state != WL_POINTER_BUTTON_STATE_RELEASED) {
+            info.cancelled = true;
+            return;
+        }
+
         const bool RELEASESPOINTERGRAB = event.state == WL_POINTER_BUTTON_STATE_RELEASED;
         auto       releasePointerGrab  = Hyprutils::Utils::CScopeGuard([this, RELEASESPOINTERGRAB] {
-            if (RELEASESPOINTERGRAB && g_pointerGrabOverview == this)
-                g_pointerGrabOverview = nullptr;
+            if (RELEASESPOINTERGRAB && g_pointerGrabOverview == this) {
+                dragCancelledAwaitingRelease = false;
+                dragAdoptedFromNative        = false;
+                g_pointerGrabOverview        = nullptr;
+
+                if (closing && closeRemovalPending)
+                    wl_event_loop_add_idle(
+                        g_pCompositor->m_wlEventLoop,
+                        [](void* data) {
+                            auto* const overview = sc<CScrollOverview*>(data);
+                            if (overview->closing && overview->closeRemovalPending && !overview->dragCancelledAwaitingRelease)
+                                removeOverview(overview);
+                        },
+                        this);
+            }
         });
+
+        if (ADOPTEDNATIVEDRAGRELEASE) {
+            if (dragActiveWindow)
+                endWindowDrag();
+            return;
+        }
 
         const bool POINTERONTOPLAYER =
             !dragPendingPrimary && !resizePointerDown && !scrollingPanPointerDown && !dragActiveWindow && !resizeActiveWindow && isPointerOnTopLayer(pMonitor.lock());
+
+        if (dragCancelledAwaitingRelease) {
+            info.cancelled = true;
+            return;
+        }
 
         if (FORWARDEDTOPLAYERRELEASE ||
             (event.state == WL_POINTER_BUTTON_STATE_PRESSED && POINTERONTOPLAYER && usesSubmapKeybinds && isOverviewSubmapActive())) {
@@ -1232,7 +1274,7 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_, PHLMONITO
 
             if (dragActiveWindow) {
                 if (dragStartMouseLocal.distanceSq(lastMousePosLocal) < CLICK_MAX_DRAG_DISTANCE * CLICK_MAX_DRAG_DISTANCE) {
-                    clearDragPending();
+                    finishWindowDragSession();
 
                     if (allowClick)
                         performClickAction(button);
@@ -1444,9 +1486,12 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_, PHLMONITO
         damage();
     };
 
-    auto onWindowClose = [this](PHLWINDOW) {
+    auto onWindowClose = [this](PHLWINDOW window) {
         if (closing)
             return;
+
+        if (dragActiveWindow && getOverviewWindowToShow(window) == getOverviewWindowToShow(dragActiveWindow.lock()))
+            cancelWindowDrag();
 
         rebuildPending = true;
         damage();
@@ -1510,13 +1555,12 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_, PHLMONITO
     };
 
     auto onKeyboardKey = [this](IKeyboard::SKeyEvent event, Event::SCallbackInfo& info) {
-        if (closing || event.state != WL_KEYBOARD_KEY_STATE_PRESSED || activeScrollOverview().get() != this)
-            return;
-
-        if (isTopLayerFocused(pMonitor.lock()))
+        if (closing || event.state != WL_KEYBOARD_KEY_STATE_PRESSED)
             return;
 
         const auto KEYSYM = getOverviewKeysym(event);
+        if (activeScrollOverview().get() != this || isTopLayerFocused(pMonitor.lock()))
+            return;
         const auto MODS   = g_pInputManager->getModsFromAllKBs() & ~(HL_MODIFIER_CAPS | HL_MODIFIER_MOD2);
 
         if ((KEYSYM == XKB_KEY_Return || KEYSYM == XKB_KEY_KP_Enter || KEYSYM == XKB_KEY_Left || KEYSYM == XKB_KEY_KP_Left || KEYSYM == XKB_KEY_Right ||
@@ -1566,6 +1610,14 @@ CScrollOverview::CScrollOverview(PHLWORKSPACE startedOn_, bool swipe_, PHLMONITO
     activateSubmapIfConfigured();
     if (!usesSubmapKeybinds)
         keyboardKeyHook = Event::bus()->m_events.input.keyboard.key.listen(onKeyboardKey);
+
+    dragKeyboardKeyHook = Event::bus()->m_events.input.keyboard.key.listen([this](IKeyboard::SKeyEvent event, Event::SCallbackInfo& info) {
+        if (closing || !dragActiveWindow || event.state != WL_KEYBOARD_KEY_STATE_PRESSED || getOverviewKeysym(event) != XKB_KEY_Escape)
+            return;
+
+        info.cancelled = true;
+        cancelWindowDrag();
+    });
 
     Pointer::Cursor::overrideController->setOverride("left_ptr", Pointer::Cursor::CURSOR_OVERRIDE_SPECIAL_ACTION);
 
@@ -2577,16 +2629,33 @@ CBox CScrollOverview::resizedWindowBox() const {
     return clampResizedOverviewBoxToWorkspace(box, WORKSPACEBOX, resizeCorner, BORDERMARGIN);
 }
 
-void CScrollOverview::beginWindowDrag(PHLWINDOW window) {
-    const auto WINDOW = getOverviewWindowToShow(window);
-    if (!shouldShowOverviewWindow(WINDOW) || !WINDOW->layoutTarget())
-        return;
-
+void CScrollOverview::initializeWindowDrag(const SWindowDragSnapshot& snapshot, bool adoptedFromNative, bool crossMonitorDrag) {
     g_pseudoFocusedWindow.reset();
     g_pseudoFocusUntil = {};
+    closeOnWindow      = snapshot.window;
+    rememberSelection(snapshot.window);
 
-    closeOnWindow = WINDOW;
-    rememberSelection(WINDOW);
+    dragActiveWindow             = snapshot.window;
+    dragOriginalWorkspace        = snapshot.workspace;
+    dragOriginalBox              = snapshot.box;
+    dragOriginalVisualBox        = snapshot.visualBox;
+    dragOriginalOverviewBox      = CBox{};
+    dragOriginalOverviewHitbox   = CBox{};
+    dragOriginalFloatSize        = snapshot.floatSize;
+    dragOriginalTapeTranslation  = snapshot.tapeTranslation;
+    dragGrabOffsetLocal          = snapshot.grabOffsetLocal;
+    dragGrabRatio                = snapshot.grabRatio;
+    dragStartedTiled             = snapshot.startedTiled;
+    dragAdoptedFromNative        = adoptedFromNative;
+    dragCrossMonitor             = crossMonitorDrag;
+    dragCancelledAwaitingRelease = false;
+}
+
+void CScrollOverview::beginWindowDrag(PHLWINDOW window) {
+    const auto WINDOW = getOverviewWindowToShow(window);
+    const auto TARGET = WINDOW ? WINDOW->layoutTarget() : nullptr;
+    if (!shouldShowOverviewWindow(WINDOW) || !TARGET)
+        return;
 
     size_t workspaceIdx = viewportCurrentWorkspace;
     for (size_t i = 0; i < images.size(); ++i) {
@@ -2597,35 +2666,95 @@ void CScrollOverview::beginWindowDrag(PHLWINDOW window) {
         }
     }
 
-    const auto TARGET             = WINDOW->layoutTarget();
-    dragStartedTiled              = !TARGET->floating();
-    dragOriginalFloatSize         = TARGET->lastFloatingSize();
-    dragOriginalTapeTranslation  = Vector2D{};
-    dragOriginalWorkspace         = WINDOW->m_workspace;
-    dragOriginalBox               = TARGET->position();
-    dragOriginalVisualBox         = WINDOW->m_group ? TARGET->position() : WINDOW->geometricBox(Desktop::View::IGeometric::GEOMETRIC_CURRENT);
-    dragOriginalOverviewBox       = CBox{};
-    dragOriginalOverviewHitbox    = CBox{};
-    dragActiveWindow              = WINDOW;
+    SWindowDragSnapshot snapshot{
+        .window       = WINDOW,
+        .workspace    = WINDOW->m_workspace,
+        .box          = TARGET->position(),
+        .visualBox    = WINDOW->m_group ? TARGET->position() : WINDOW->geometricBox(Desktop::View::IGeometric::GEOMETRIC_CURRENT),
+        .floatSize    = TARGET->lastFloatingSize(),
+        .startedTiled = !TARGET->floating(),
+    };
 
     const auto MONITOR = pMonitor.lock();
     if (MONITOR && workspaceIdx < images.size()) {
         const auto WORKSPACEOFFSET = workspaceOverviewOffset(workspaceIdx, activeWorkspaceIndex(), getWorkspaceRenderedPitch(MONITOR, scale->value(), layout));
         const auto WINDOWBOX       = getOverviewDragWindowBox(WINDOW, MONITOR, scale->value(), viewOffset->value(), WORKSPACEOFFSET, layout);
-        dragGrabOffsetLocal        = dragStartMouseLocal - WINDOWBOX.pos();
-        dragGrabRatio              = Vector2D{
-            WINDOWBOX.width > 0.0 ? dragGrabOffsetLocal.x / WINDOWBOX.width : 0.5,
-            WINDOWBOX.height > 0.0 ? dragGrabOffsetLocal.y / WINDOWBOX.height : 0.5,
+        snapshot.grabOffsetLocal   = dragStartMouseLocal - WINDOWBOX.pos();
+        snapshot.grabRatio         = Vector2D{
+            WINDOWBOX.width > 0.0 ? snapshot.grabOffsetLocal.x / WINDOWBOX.width : 0.5,
+            WINDOWBOX.height > 0.0 ? snapshot.grabOffsetLocal.y / WINDOWBOX.height : 0.5,
         };
-        if (const auto ALGO = overviewScrollingAlgorithmForWorkspace(WINDOW->m_workspace); ALGO && ALGO->m_scrollingData && ALGO->m_scrollingData->controller)
-            dragOriginalTapeTranslation = overviewScrollingCameraTranslation(ALGO);
-        refreshDragOriginalOverviewBoxes();
-    } else {
-        dragGrabOffsetLocal = Vector2D{};
-        dragGrabRatio       = Vector2D{0.5, 0.5};
     }
 
+    if (MONITOR && workspaceIdx < images.size())
+        snapshot.tapeTranslation = overviewScrollingCameraTranslation(overviewScrollingAlgorithmForWorkspace(snapshot.workspace));
+
+    initializeWindowDrag(snapshot, false, ScrollOverview::Config::getCrossMonitorDrag());
+    if (MONITOR && workspaceIdx < images.size())
+        refreshDragOriginalOverviewBoxes();
     updateWindowDrag();
+}
+
+std::optional<CScrollOverview::SWindowDragSnapshot> CScrollOverview::snapshotNativeWindowDrag(Layout::Supplementary::CDragStateController* dragController,
+                                                                                              PHLWINDOW expectedWindow) const {
+    if (!dragController || dragController->mode() != MBIND_MOVE || !dragController->dragThresholdReached() || !g_pInputManager)
+        return std::nullopt;
+
+    const auto TARGET = dragController->target();
+    if (!TARGET)
+        return std::nullopt;
+
+    const auto WINDOW = getOverviewWindowToShow(TARGET->window());
+    if (!shouldShowOverviewWindow(WINDOW) || !WINDOW->layoutTarget())
+        return std::nullopt;
+    if (expectedWindow && WINDOW != getOverviewWindowToShow(expectedWindow))
+        return std::nullopt;
+
+    const auto BOX = TARGET->position();
+    SWindowDragSnapshot snapshot{
+        .window       = WINDOW,
+        .workspace    = WINDOW->m_workspace,
+        .box          = BOX,
+        .visualBox    = WINDOW->m_group ? BOX : WINDOW->geometricBox(Desktop::View::IGeometric::GEOMETRIC_CURRENT),
+        .floatSize    = TARGET->lastFloatingSize(),
+        .startedTiled = dragController->draggingTiled(),
+    };
+
+    const auto CURSOR = g_pInputManager->getMouseCoordsInternal();
+    snapshot.grabRatio = Vector2D{
+        snapshot.visualBox.width > 0.0 ? (CURSOR.x - snapshot.visualBox.x) / snapshot.visualBox.width : 0.5,
+        snapshot.visualBox.height > 0.0 ? (CURSOR.y - snapshot.visualBox.y) / snapshot.visualBox.height : 0.5,
+    };
+
+    return snapshot;
+}
+
+bool CScrollOverview::adoptNativeWindowDrag(PHLWINDOW expectedWindow) {
+    if (dragActiveWindow || g_finishingAdoptedNativeDrag || !g_layoutManager)
+        return false;
+
+    const auto& DRAGCONTROLLER = g_layoutManager->dragController();
+    auto        snapshot       = snapshotNativeWindowDrag(DRAGCONTROLLER.get(), expectedWindow);
+    if (!snapshot)
+        return false;
+
+    g_finishingAdoptedNativeDrag = true;
+    [[maybe_unused]] auto restoreFinishingAdoptedDrag = Hyprutils::Utils::CScopeGuard([] { g_finishingAdoptedNativeDrag = false; });
+    finishNativeDragAdoption(DRAGCONTROLLER.get());
+    g_layoutManager->endDragTarget();
+
+    if (!shouldShowOverviewWindow(snapshot->window) || !snapshot->window->layoutTarget())
+        return false;
+
+    snapshot->tapeTranslation = overviewScrollingCameraTranslation(overviewScrollingAlgorithmForWorkspace(snapshot->workspace));
+    initializeWindowDrag(*snapshot, true, true);
+    dragStartMouseLocal   = getOverviewMousePosLocal(pMonitor.lock());
+    lastMousePosLocal     = dragStartMouseLocal;
+    g_pointerGrabOverview = this;
+
+    requestInputFrame();
+    damage();
+    return true;
 }
 
 void CScrollOverview::beginWindowResize() {
@@ -2653,9 +2782,49 @@ void CScrollOverview::beginWindowResize() {
     updateWindowResize();
 }
 
+void CScrollOverview::ensureDragDestinationOverview() {
+    if (!dragActiveWindow || !g_pInputManager || !dragCrossMonitor)
+        return;
+
+    const auto GLOBALCURSOR = g_pInputManager->getMouseCoordsInternal();
+    auto       monitor      = State::monitorState()->query().vec(GLOBALCURSOR).run();
+    if (!monitor || !monitor->m_enabled || !monitor->logicalBox().containsPoint(GLOBALCURSOR) || monitor == pMonitor.lock())
+        return;
+
+    if (const auto EXISTING = scrollOverviewForMonitor(monitor)) {
+        if (EXISTING->isClosing()) {
+            EXISTING->reopen();
+            std::erase_if(dragTransientOverviews, [&EXISTING](const auto& transient) { return transient == EXISTING; });
+        }
+        return;
+    }
+
+    const auto [overview, created] = openOverview(monitor);
+    if (!overview)
+        return;
+
+    if (created && overview.get() != this)
+        dragTransientOverviews.emplace_back(overview);
+    else if (overview->isClosing()) {
+        overview->reopen();
+        std::erase_if(dragTransientOverviews, [&overview](const auto& transient) { return transient == overview; });
+    }
+
+    overview->requestInputFrame();
+    overview->damage();
+}
+
 void CScrollOverview::updateWindowDrag() {
     if (!dragActiveWindow)
         return;
+
+    const auto WINDOW = getOverviewWindowToShow(dragActiveWindow.lock());
+    if (!shouldShowOverviewWindow(WINDOW) || !WINDOW->layoutTarget()) {
+        cancelWindowDrag();
+        return;
+    }
+
+    ensureDragDestinationOverview();
 
     for (const auto& overview : scrollOverviews()) {
         if (!overview)
@@ -2700,11 +2869,51 @@ void CScrollOverview::updateWindowResize() {
     damage();
 }
 
+void CScrollOverview::finishWindowDragSession(const SP<IOverview>& persistentDestination) {
+    clearDragPending();
+
+    auto transientOverviews = std::move(dragTransientOverviews);
+    dragTransientOverviews.clear();
+
+    const bool DESTINATIONCREATEDBYDRAG = persistentDestination && std::ranges::any_of(transientOverviews, [&persistentDestination](const auto& ref) {
+        return ref.lock() == persistentDestination;
+    });
+    if (DESTINATIONCREATEDBYDRAG)
+        markCrossMonitorDragSession(this, persistentDestination);
+
+    for (const auto& transientRef : transientOverviews) {
+        const auto TRANSIENT = transientRef.lock();
+        if (!TRANSIENT || TRANSIENT == persistentDestination || TRANSIENT.get() == this || std::ranges::find(scrollOverviews(), TRANSIENT) == scrollOverviews().end())
+            continue;
+
+        TRANSIENT->dismissTransient();
+    }
+
+    for (const auto& overview : scrollOverviews()) {
+        if (!overview)
+            continue;
+
+        overview->requestInputFrame();
+        overview->damage();
+    }
+}
+
+void CScrollOverview::cancelWindowDrag() {
+    if (!dragActiveWindow && dragTransientOverviews.empty())
+        return;
+
+    if (dragActiveWindow && g_pointerGrabOverview == this)
+        dragCancelledAwaitingRelease = true;
+
+    finishWindowDragSession();
+}
+
 void CScrollOverview::clearDragPending() {
     dragPendingPrimary          = false;
     dragActiveWindow.reset();
     dragOriginalWorkspace.reset();
     dragStartedTiled            = false;
+    dragCrossMonitor            = false;
     dragOriginalFloatSize       = Vector2D{};
     dragOriginalTapeTranslation = Vector2D{};
     dragGrabOffsetLocal         = Vector2D{};
@@ -2979,10 +3188,17 @@ bool CScrollOverview::moveScrollingStackSelection(bool next) {
 }
 
 void CScrollOverview::endWindowDrag() {
+    SP<IOverview> persistentDestination;
+    auto          finishDragSession = Hyprutils::Utils::CScopeGuard([this, &persistentDestination] { finishWindowDragSession(persistentDestination); });
+
+    ensureDragDestinationOverview();
+
     const auto WINDOW = getOverviewWindowToShow(dragActiveWindow.lock());
     const auto TARGET = WINDOW ? WINDOW->layoutTarget() : nullptr;
     const auto SPACE  = TARGET ? TARGET->space() : nullptr;
     const auto ALGO   = SPACE ? SPACE->algorithm() : nullptr;
+    if (!WINDOW || !TARGET)
+        return;
 
     const auto          targetOverview = scrollOverviewAt(g_pInputManager->getMouseCoordsInternal());
     auto*               dropOverview   = targetOverview ? dynamic_cast<CScrollOverview*>(targetOverview.get()) : nullptr;
@@ -3004,13 +3220,11 @@ void CScrollOverview::endWindowDrag() {
     CDropIndicator::SDropAnchor dropAnchor;
     std::string         dropDirection;
 
-    if (!DROPWORKSPACE) {
-        clearDragPending();
-        damage();
-        if (dropOverview && dropOverview != this)
-            dropOverview->damage();
+    if (!DROPWORKSPACE)
         return;
-    }
+
+    if (dropOverview != this)
+        persistentDestination = targetOverview;
 
     const auto SOURCEFULLSCREENWINDOW = ORIGINALWORKSPACE ? getOverviewWindowToShow(Fullscreen::controller()->getFullscreenWindow(ORIGINALWORKSPACE)) : PHLWINDOW{};
     const bool RESTORESOURCEFULLSCREENFOCUS = WINDOW && WINDOW->m_isFloating && MOVEWORKSPACE && shouldShowOverviewWindow(SOURCEFULLSCREENWINDOW) &&
@@ -3171,8 +3385,8 @@ void CScrollOverview::endWindowDrag() {
         g_pseudoFocusUntil    = Time::steadyNow() + POST_DROP_PSEUDO_FOCUS_DURATION;
     }
 
-    clearDragPending();
-    rebuildPending = true;
+    dragCancelledAwaitingRelease = false;
+    rebuildPending               = true;
     damage();
     if (dropOverview != this) {
         dropOverview->rebuildPending = true;
@@ -4781,15 +4995,39 @@ bool CScrollOverview::shouldHandleSurfaceDamage(SP<CWLSurfaceResource> surface) 
 }
 
 void CScrollOverview::close() {
+    close(ECloseMode::COMMIT_SELECTION);
+}
+
+void CScrollOverview::dismissTransient() {
+    if (closing && !closeRemovalPending) {
+        setClosing(false);
+        closeApplied = false;
+    }
+
+    close(ECloseMode::PRESERVE_MONITOR_STATE);
+}
+
+void CScrollOverview::close(ECloseMode mode) {
     if (closeApplied)
         return;
     closeApplied = true;
 
-    const bool ACTIVATESELECTION = activeScrollOverview().get() == this;
-    setClosing(true);
+    const bool PRESERVEMONITORSTATE = mode == ECloseMode::PRESERVE_MONITOR_STATE;
+    const bool ACTIVATESELECTION    = !PRESERVEMONITORSTATE && activeScrollOverview().get() == this;
+    const auto MONITOR              = pMonitor.lock();
+    const auto SELECTEDWORKSPACE    = PRESERVEMONITORSTATE ?
+        (MONITOR ? MONITOR->m_activeWorkspace : PHLWORKSPACE{}) :
+        (viewportCurrentWorkspace < images.size() && images[viewportCurrentWorkspace] ? images[viewportCurrentWorkspace]->pWorkspace : PHLWORKSPACE{});
 
-    const auto SELECTEDWORKSPACE =
-        viewportCurrentWorkspace < images.size() && images[viewportCurrentWorkspace] ? images[viewportCurrentWorkspace]->pWorkspace : PHLWORKSPACE{};
+    if (PRESERVEMONITORSTATE) {
+        closeOnWindow.reset();
+        focusSyncedFromWorkspaceID = WORKSPACE_INVALID;
+        startedOn                  = SELECTEDWORKSPACE;
+        viewportCurrentWorkspace   = activeWorkspaceIndex();
+        viewOffset->setValueAndWarp(Vector2D{});
+    }
+
+    setClosing(true);
 
     const auto finishClose = [&](const PHLWORKSPACE& finalWorkspace, const PHLWINDOW& finalWindow) {
         emitFullscreenVisibilityState(getOverviewFullscreenVisibilityWindow(finalWorkspace, finalWindow), false);
@@ -4801,10 +5039,14 @@ void CScrollOverview::close() {
             damage();
         }
 
-        scale->setCallbackOnEnd([this](auto) { removeOverview(this); });
+        closeRemovalPending = true;
+        scale->setCallbackOnEnd([this](auto) {
+            if (!dragCancelledAwaitingRelease)
+                removeOverview(this);
+        });
     };
 
-    if (!closeOnWindow && (!SELECTEDWORKSPACE || SELECTEDWORKSPACE == pMonitor->m_activeWorkspace)) {
+    if (!PRESERVEMONITORSTATE && !closeOnWindow && (!SELECTEDWORKSPACE || SELECTEDWORKSPACE == pMonitor->m_activeWorkspace)) {
         const auto FOCUSEDWINDOW = getOverviewWindowToShow(Desktop::focusState()->window());
         if (!SELECTEDWORKSPACE || (FOCUSEDWINDOW && FOCUSEDWINDOW->m_workspace == SELECTEDWORKSPACE))
             closeOnWindow = FOCUSEDWINDOW;
@@ -4922,7 +5164,8 @@ void CScrollOverview::reopen() {
         return;
 
     scale->setCallbackOnEnd({});
-    closeApplied = false;
+    closeApplied        = false;
+    closeRemovalPending = false;
     setClosing(false);
     activateSubmapIfConfigured();
     emitFullscreenVisibilityState(Desktop::focusState()->window(), true);
@@ -5158,12 +5401,13 @@ static Vector2D hyprlerp(const Vector2D& from, const Vector2D& to, const float p
 void CScrollOverview::setClosing(bool closing_) {
     closing = closing_;
     if (closing) {
+        removeFromCrossMonitorDragSession(this);
+        cancelWindowDrag();
         transferSharedStateOwnership();
         inputFramePending = false;
         if (scrollingPanPointerDown)
             endScrollingPan();
         releaseTopLayerPointerButtons(Time::millis(Time::steadyNow()));
-        clearDragPending();
         restoreSubmapIfActive();
     } else
         applyWorkspaceAnimationOverrides();
@@ -5173,6 +5417,7 @@ void CScrollOverview::releaseInputListeners() {
     if (scrollingPanPointerDown)
         endScrollingPan();
     releaseTopLayerPointerButtons(Time::millis(Time::steadyNow()));
+    cancelWindowDrag();
     clearDragPending();
     submapMouseClickPending = false;
     submapMouseClickButton  = 0;
@@ -5183,6 +5428,7 @@ void CScrollOverview::releaseInputListeners() {
     mouseButtonHook.reset();
     touchDownHook.reset();
     keyboardKeyHook.reset();
+    dragKeyboardKeyHook.reset();
 }
 
 void CScrollOverview::activateSubmapIfConfigured() {

--- a/scrollOverview.hpp
+++ b/scrollOverview.hpp
@@ -48,6 +48,7 @@ class CScrollOverview : public IOverview {
 
     // close without a selection
     void         close() override;
+    void         dismissTransient() override;
     bool         isClosing() const override;
     void         reopen() override;
     void         selectHoveredWorkspace() override;
@@ -55,8 +56,27 @@ class CScrollOverview : public IOverview {
     bool         windowDispatcherAction(const std::string& action) override;
 
     void         fullRender() override;
+    bool         adoptNativeWindowDrag(PHLWINDOW expectedWindow = {});
 
   private:
+    enum class ECloseMode {
+        COMMIT_SELECTION,
+        PRESERVE_MONITOR_STATE,
+    };
+
+    struct SWindowDragSnapshot {
+        PHLWINDOW    window;
+        PHLWORKSPACE workspace;
+        CBox         box;
+        CBox         visualBox;
+        Vector2D     floatSize;
+        Vector2D     tapeTranslation;
+        Vector2D     grabOffsetLocal;
+        Vector2D     grabRatio = Vector2D{0.5, 0.5};
+        bool         startedTiled = false;
+    };
+
+    void       close(ECloseMode mode);
     void   rebuildWorkspaceImages();
     void   seedRememberedSelections();
     void   redrawAll(bool forcelowres = false);
@@ -103,10 +123,16 @@ class CScrollOverview : public IOverview {
     CBox      draggedWindowBoxFor(PHLWINDOW window, size_t workspaceIdx, const Vector2D& pointLocal, const Vector2D& grabRatio) const;
     CBox      draggedWindowGlobalBox() const;
     void      refreshDragOriginalOverviewBoxes();
-    void      clearDragPending();
-    void      beginWindowDrag(PHLWINDOW window);
-    void      updateWindowDrag();
-    void      endWindowDrag();
+    void                        clearDragPending();
+    void                        beginWindowDrag(PHLWINDOW window);
+    std::optional<SWindowDragSnapshot> snapshotNativeWindowDrag(Layout::Supplementary::CDragStateController* dragController,
+                                                                 PHLWINDOW expectedWindow) const;
+    void initializeWindowDrag(const SWindowDragSnapshot& snapshot, bool adoptedFromNative, bool crossMonitorDrag);
+    void                        ensureDragDestinationOverview();
+    void                        updateWindowDrag();
+    void                        endWindowDrag();
+    void                        finishWindowDragSession(const SP<IOverview>& persistentDestination = {});
+    void                        cancelWindowDrag();
     CBox      resizedWindowBox() const;
     void      beginWindowResize();
     void      updateWindowResize();
@@ -180,6 +206,7 @@ class CScrollOverview : public IOverview {
     PHLWINDOWREF                     closeOnWindow;
     PHLWINDOWREF                     dragActiveWindow;
     PHLWORKSPACEREF                  dragOriginalWorkspace;
+    std::vector<WP<IOverview>>                    dragTransientOverviews;
     PHLWORKSPACEREF                  scrollingPanWorkspace;
     PHLWINDOWREF                     scrollingPanInitialWindow;
     PHLWINDOWREF                     resizePendingWindow;
@@ -202,10 +229,13 @@ class CScrollOverview : public IOverview {
     size_t                           resizeWorkspaceIdx     = 0;
     Layout::eRectCorner              resizeCorner           = Layout::CORNER_NONE;
     bool                             dragPendingPrimary    = false;
+    bool                                          dragCancelledAwaitingRelease      = false;
     bool                             resizePointerDown     = false;
     bool                             scrollingPanPointerDown = false;
     bool                             submapMouseClickPending = false;
     bool                             dragStartedTiled      = false;
+    bool                             dragAdoptedFromNative = false;
+    bool                             dragCrossMonitor      = false;
     bool                             emittingFullscreenVisibilityState = false;
     bool                             inputConfigOverridden = false;
     bool                             realtimePreviewTimerArmed = false;
@@ -271,6 +301,7 @@ class CScrollOverview : public IOverview {
 
     bool                             closing = false;
     bool                             closeApplied = false; // close() has run its teardown; guards against double-invocation
+    bool                                               closeRemovalPending = false;
 
     CHyprSignalListener             mouseMoveHook;
     CHyprSignalListener             mouseButtonHook;
@@ -283,6 +314,7 @@ class CScrollOverview : public IOverview {
     CHyprSignalListener             windowActiveHook;
     CHyprSignalListener             windowFullscreenHook;
     CHyprSignalListener             keyboardKeyHook;
+    CHyprSignalListener                                dragKeyboardKeyHook;
     CHyprSignalListener             workspaceCreatedHook;
     CHyprSignalListener             workspaceRemovedHook;
 


### PR DESCRIPTION
Hey, thanks for the plugin. I use it on a multi-monitor setup and have expanded on #52 so a drag can continue onto a monitor whose overview wasn't already open.

With `cross_monitor_drag = true`:

* drag a window from one monitor to another without opening both overviews first
* the second monitor's overview opens automatically as you drag onto it
* you can drop the window onto a workspace there without releasing and starting again
* normal Hyprland window drags can also hand over into ScrollOverview when another overview is already open

The option defaults to `false`, so existing behaviour is unchanged unless enabled.

I also added `layout = auto` for mixed portrait/landscape setups.

## Demo

https://github.com/user-attachments/assets/ad8cc8fb-9027-4105-928f-fa4637ee1df5

## Validation

I've tested it locally with two monitors, including successful and cancelled drags, repeated drags between monitors, normal Hyprland window drags, the feature disabled, and mixed portrait/landscape layouts.

It would still be useful to test on setups with more than two monitors.

Let me know if anything needs tweaking.
